### PR TITLE
feat: training improvements — W&B logging, Optuna HPO, discriminative LR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,14 @@ dgs = [
 ]
 train = [
     "sign-language-segmentation[dgs]",
+    "wandb",
+    "optuna",
+    "optuna-integration[pytorch_lightning]",
+    "pyyaml",
 ]
 dev = [
     "pytest",
     "ruff",
-    "wandb",
 ]
 server = [
     "Flask",
@@ -57,7 +60,7 @@ where = ["."]
 include = ["sign_language_segmentation*"]
 
 [tool.setuptools.package-data]
-sign_language_segmentation = ["**/*.json", "**/*.ckpt"]
+sign_language_segmentation = ["**/*.json", "**/*.ckpt", "**/*.yaml"]
 
 [tool.pytest.ini_options]
 addopts = "-v"

--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -7,9 +7,11 @@ import torch
 parser = ArgumentParser()
 
 # wandb
-parser.add_argument('--no_wandb', action='store_true', default=True)
+parser.add_argument('--no_wandb', action='store_true', default=False)
 parser.add_argument('--run_name', type=str, default=None)
 parser.add_argument('--wandb_dir', type=str, default='.')
+parser.add_argument('--wandb_entity', type=str, default=None)
+parser.add_argument('--wandb_project', type=str, default='segmentation')
 
 # Training
 parser.add_argument('--seed', type=int, default=42)
@@ -20,6 +22,8 @@ parser.add_argument('--patience', type=int, default=10)
 parser.add_argument('--batch_size', type=int, default=8)
 parser.add_argument('--num_frames', type=int, default=1024, help='frames per training sample')
 parser.add_argument('--learning_rate', type=float, default=1e-3)
+parser.add_argument('--lr_scale_backbone', type=float, default=1.0,
+                    help='LR multiplier for backbone (CNN + transformer). 1.0=same as head, 0.1=10x smaller')
 parser.add_argument('--max_time', type=str, default="00:00:30:00",
                     help='max wall time DD:HH:MM:SS (default: 30 min)')
 parser.add_argument('--optimizer',
@@ -27,6 +31,10 @@ parser.add_argument('--optimizer',
                     default='adamw-onecycle')
 parser.add_argument('--finetune_from', type=str, default=None,
                     help='checkpoint to fine-tune from')
+parser.add_argument('--optuna', type=str, default=None, metavar='YAML',
+                    help='run Optuna hyperparameter search using ranges from YAML file')
+parser.add_argument('--optuna_trials', type=int, default=50,
+                    help='number of Optuna trials (default: 50)')
 
 # Data
 parser.add_argument('--corpus', default='/mnt/nas/GCS/sign-external-datasets/dgs-corpus')

--- a/sign_language_segmentation/hpo.py
+++ b/sign_language_segmentation/hpo.py
@@ -1,0 +1,92 @@
+"""optuna hyperparameter optimization for the segmentation model.
+
+The search space is defined in a YAML file with two sections:
+  architecture: model structure params (skipped when fine-tuning)
+  training: optimization and regularization params (always searched)
+
+See optuna.yaml for the default search space.
+"""
+from pathlib import Path
+
+import optuna
+import yaml
+
+
+def load_search_space(path: str | Path, skip_architecture: bool = False) -> tuple[dict, str]:
+    """load search space from YAML and flatten into a single param dict.
+
+    When skip_architecture is True (fine-tuning), only the 'training'
+    section is returned.
+
+    Returns (params, monitor_metric).
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Optuna search space file not found: {path}")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    monitor_metric = raw.get("monitor_metric", "value")
+
+    params: dict = {}
+    if not skip_architecture:
+        params.update(raw.get("architecture", {}))
+    params.update(raw.get("training", {}))
+    return params, monitor_metric
+
+
+def sample_hyperparams(trial: optuna.Trial, search_space: dict) -> dict:
+    """sample hyperparameters from an Optuna trial using a search space dict."""
+    overrides: dict = {}
+    for name, spec in search_space.items():
+        param_type = spec["type"]
+        if param_type == "float":
+            overrides[name] = trial.suggest_float(
+                name, low=spec["low"], high=spec["high"], log=spec.get("log", False),
+            )
+        elif param_type == "int":
+            overrides[name] = trial.suggest_int(
+                name, low=spec["low"], high=spec["high"], step=spec.get("step", 1),
+            )
+        elif param_type == "categorical":
+            overrides[name] = trial.suggest_categorical(name, choices=spec["choices"])
+        else:
+            raise ValueError(f"Unknown param type '{param_type}' for '{name}'")
+    return overrides
+
+
+def run_study(
+    train_fn,
+    search_space: dict,
+    n_trials: int,
+    metric_name: str = "value",
+    wandb_entity: str | None = None,
+    wandb_project: str | None = None,
+    no_wandb: bool = False,
+) -> optuna.Study:
+    """create and run an Optuna study."""
+    wandb_callback = None
+    if not no_wandb:
+        from optuna_integration import WeightsAndBiasesCallback
+        wandb_callback = WeightsAndBiasesCallback(
+            metric_name=metric_name,
+            wandb_kwargs={"entity": wandb_entity, "project": wandb_project},
+            as_multirun=True,
+        )
+
+    def objective(trial: optuna.Trial) -> float:
+        overrides = sample_hyperparams(trial=trial, search_space=search_space)
+        overrides["_trial"] = trial
+        return train_fn(overrides=overrides)
+
+    if wandb_callback:
+        objective = wandb_callback.track_in_wandb()(objective)
+
+    study = optuna.create_study(direction="maximize", study_name="segmentation-hpo")
+    study.optimize(
+        objective,
+        n_trials=n_trials,
+        callbacks=[wandb_callback] if wandb_callback else [],
+    )
+    return study

--- a/sign_language_segmentation/model/model.py
+++ b/sign_language_segmentation/model/model.py
@@ -119,7 +119,7 @@ class PoseTaggingModel(pl.LightningModule):
     REFERENCE_FPS = RoPETransformerEncoderLayer.REFERENCE_FPS
 
     def __init__(self,
-                 pose_dims: (int, int) = (178, 3),
+                 pose_dims: tuple[int, int] = (178, 3),
                  hidden_dim: int = 384,
                  encoder_depth: int = 6,
                  num_classes: int = len(BIO),
@@ -134,6 +134,7 @@ class PoseTaggingModel(pl.LightningModule):
                  attn_dropout: float = 0.1,
                  # Optimizer
                  optimizer: str = "adamw-onecycle",
+                 lr_scale_backbone: float = 1.0,
                  # Stored as hparams for evaluate.py (not used in forward)
                  fps_aug: bool = False,
                  frame_dropout: float = 0.0,
@@ -146,6 +147,7 @@ class PoseTaggingModel(pl.LightningModule):
         self.steps_per_epoch = steps_per_epoch
         self.max_epochs = max_epochs
         self._optimizer_name = optimizer
+        self._lr_scale_backbone = lr_scale_backbone
 
         self.sign_loss_fn = nn.NLLLoss(reduction='none')
         self.phrase_loss_fn = nn.NLLLoss(reduction='none')
@@ -287,14 +289,25 @@ class PoseTaggingModel(pl.LightningModule):
         return total_loss
 
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(self.parameters(), lr=self.learning_rate, weight_decay=0.01)
+        backbone_lr = self.learning_rate * self._lr_scale_backbone
+        head_lr = self.learning_rate
+
+        param_groups = [
+            {"params": self.frame_cnn.parameters(), "lr": backbone_lr},
+            {"params": self.input_norm.parameters(), "lr": backbone_lr},
+            {"params": self.encoder_attn.parameters(), "lr": backbone_lr},
+            {"params": self.sign_bio_head.parameters(), "lr": head_lr},
+            {"params": self.sentence_bio_head.parameters(), "lr": head_lr},
+        ]
+
+        optimizer = torch.optim.AdamW(param_groups, lr=head_lr, weight_decay=0.01)
         if self._optimizer_name == "adam":
-            optimizer = torch.optim.Adam(self.parameters(), lr=self.learning_rate)
+            optimizer = torch.optim.Adam(param_groups, lr=head_lr)
 
         if self._optimizer_name in ("adamw-onecycle", "adamw", None):
             scheduler = torch.optim.lr_scheduler.OneCycleLR(
                 optimizer,
-                max_lr=self.learning_rate,
+                max_lr=[backbone_lr, backbone_lr, backbone_lr, head_lr, head_lr],
                 epochs=self.max_epochs,
                 steps_per_epoch=self.steps_per_epoch,
                 pct_start=0.1,

--- a/sign_language_segmentation/optuna.yaml
+++ b/sign_language_segmentation/optuna.yaml
@@ -1,0 +1,78 @@
+# optuna hyperparameter search space
+#
+# monitor_metric: the validation metric to maximize
+# parameters are split into two sections:
+#   architecture: model structure params (skipped when fine-tuning from a checkpoint)
+#   training: optimization and regularization params (always searched)
+#
+# supported types:
+#   float:       {type: float, low: 1e-5, high: 1e-2, log: true}
+#   int:         {type: int, low: 2, high: 8, step: 2}
+#   categorical: {type: categorical, choices: [adam, adamw, adamw-onecycle]}
+
+monitor_metric: validation_hm_iou
+
+architecture:
+  hidden_dim:
+    type: categorical
+    choices: [128, 256, 384, 512]
+
+  encoder_depth:
+    type: int
+    low: 2
+    high: 6
+
+  attn_nhead:
+    type: categorical
+    choices: [4, 8]
+
+  attn_ff_mult:
+    type: int
+    low: 1
+    high: 4
+
+training:
+  learning_rate:
+    type: float
+    low: 1.0e-6
+    high: 1.0e-2
+    log: true
+
+  lr_scale_backbone:
+    type: float
+    low: 0.01
+    high: 1.0
+    log: true
+
+  epochs:
+    type: int
+    low: 50
+    high: 100
+
+  optimizer:
+    type: categorical
+    choices: [adam, adamw, adamw-onecycle, cosine]
+
+  dice_loss_weight:
+    type: float
+    low: 0.0
+    high: 3.0
+
+  attn_dropout:
+    type: float
+    low: 0.0
+    high: 0.3
+
+  frame_dropout:
+    type: float
+    low: 0.0
+    high: 0.3
+
+  body_part_dropout:
+    type: float
+    low: 0.0
+    high: 0.2
+
+  batch_size:
+    type: categorical
+    choices: [4, 8, 16]

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -1,4 +1,6 @@
-import os
+import json
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
@@ -12,8 +14,12 @@ from sign_language_segmentation.datasets.common import Split, collate_fn
 from sign_language_segmentation.model.model import PoseTaggingModel
 
 
-def get_dataloader(split: Split, batch_size: int = None, num_frames: int = None,
-                   persistent_workers: bool = True) -> DataLoader:
+def get_dataloader(
+    split: Split,
+    batch_size: int | None = None,
+    num_frames: int | None = None,
+    persistent_workers: bool = True,
+) -> DataLoader:
     dataset = DGSSegmentationDataset(
         corpus_dir=args.corpus,
         poses_dir=args.poses,
@@ -36,14 +42,45 @@ def get_dataloader(split: Split, batch_size: int = None, num_frames: int = None,
     )
 
 
-if __name__ == '__main__':
-    LOGGER = None
-    if not args.no_wandb:
-        LOGGER = WandbLogger(project="pose-to-segments", log_model=False,
-                             offline=False, name=args.run_name,
-                             save_dir=args.wandb_dir)
+_DEFAULT_MONITOR_METRIC = "validation_hm_iou"
 
-    train_loader = get_dataloader(Split.TRAIN)
+
+def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_METRIC) -> float:
+    """run a single training loop. returns best monitor_metric value.
+
+    Without Optuna, all hyperparameters come from CLI args (see args.py for
+    defaults). With Optuna, sampled values are passed via overrides and
+    monitor_metric is read from the YAML search space config.
+
+    overrides: dict of arg names -> values that replace the CLI defaults
+    (used by Optuna to inject sampled hyperparams).
+    monitor_metric: validation metric to maximize and monitor for early stopping.
+    """
+    overrides = overrides or {}
+
+    def _get(name: str):
+        return overrides[name] if name in overrides else getattr(args, name)
+
+    logger = None
+    if not args.no_wandb:
+        if overrides and "_trial" in overrides:
+            import wandb
+            trial_num = overrides["_trial"].number
+            run_name = f"{args.run_name}-t{trial_num}"
+            wandb.run.name = run_name
+            logger = WandbLogger(experiment=wandb.run)
+        else:
+            logger = WandbLogger(
+                entity=args.wandb_entity,
+                project=args.wandb_project,
+                name=args.run_name,
+                save_dir=args.wandb_dir,
+                log_model=False,
+            )
+        effective_args = {**vars(args), **overrides}
+        logger.log_hyperparams(effective_args)
+
+    train_loader = get_dataloader(Split.TRAIN, batch_size=_get("batch_size"))
     validation_loader = get_dataloader(Split.DEV, batch_size=1)
 
     example_datum = train_loader.dataset[0]
@@ -54,18 +91,19 @@ if __name__ == '__main__':
 
     model_kwargs = dict(
         pose_dims=(pose_joints, pose_dims),
-        hidden_dim=args.hidden_dim,
-        encoder_depth=args.encoder_depth,
-        learning_rate=args.learning_rate,
+        hidden_dim=_get("hidden_dim"),
+        encoder_depth=_get("encoder_depth"),
+        learning_rate=_get("learning_rate"),
+        lr_scale_backbone=_get("lr_scale_backbone"),
         steps_per_epoch=steps_per_epoch,
-        max_epochs=args.epochs,
-        dice_loss_weight=args.dice_loss_weight,
-        optimizer=args.optimizer,
-        attn_nhead=args.attn_nhead,
-        attn_ff_mult=args.attn_ff_mult,
-        attn_dropout=args.attn_dropout,
+        max_epochs=_get("epochs"),
+        dice_loss_weight=_get("dice_loss_weight"),
+        optimizer=_get("optimizer"),
+        attn_nhead=_get("attn_nhead"),
+        attn_ff_mult=_get("attn_ff_mult"),
+        attn_dropout=_get("attn_dropout"),
         fps_aug=args.fps_aug,
-        frame_dropout=args.frame_dropout,
+        frame_dropout=_get("frame_dropout"),
         num_frames=args.num_frames,
     )
 
@@ -78,10 +116,17 @@ if __name__ == '__main__':
     total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     print(f"Parameters: {total_params:,}")
 
-    model_dir = f"models/{args.run_name or 'model'}"
-    os.makedirs(model_dir, exist_ok=True)
+    model_dir = Path("dist") / (args.run_name or "model")
+    model_dir.mkdir(parents=True, exist_ok=True)
 
-    monitor_metric = "validation_hm_iou"
+    # write split manifest
+    manifest = {
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+        "dataset": "dgs",
+    }
+    manifest_path = model_dir / "split_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"Split manifest: {manifest_path}")
 
     callbacks = [
         EarlyStopping(monitor=monitor_metric, patience=args.patience, verbose=True, mode='max'),
@@ -98,20 +143,66 @@ if __name__ == '__main__':
         ),
     ]
 
+    # add Optuna pruning callback when running a sweep
+    if overrides and "_trial" in overrides:
+        from optuna_integration import PyTorchLightningPruningCallback
+        callbacks.append(PyTorchLightningPruningCallback(
+            trial=overrides["_trial"], monitor=monitor_metric,
+        ))
+
     trainer = pl.Trainer(
-        max_epochs=args.epochs,
+        max_epochs=_get("epochs"),
         max_time=args.max_time,
         precision="bf16-mixed",
-        logger=LOGGER,
+        logger=logger,
         callbacks=callbacks,
         log_every_n_steps=10,
         accelerator=args.device,
         devices=args.gpus,
+        enable_progress_bar=not overrides,
     )
 
     trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=validation_loader)
 
-    best_ckpt = os.path.join(model_dir, "best.ckpt")
-    if os.path.exists(best_ckpt):
-        print(f"\nBest checkpoint: {best_ckpt}")
-        print("Copy to dist/2026/best.ckpt to deploy for inference.")
+    best_score = trainer.callback_metrics.get(monitor_metric)
+    best_val = float(best_score) if best_score is not None else 0.0
+
+    if not overrides:
+        best_ckpt = model_dir / "best.ckpt"
+        if best_ckpt.exists():
+            print(f"\nBest checkpoint: {best_ckpt}")
+            print("Copy to dist/2026/best.ckpt to deploy for inference.")
+
+    return best_val
+
+
+if __name__ == '__main__':
+    if args.optuna:
+        if not args.run_name:
+            raise ValueError("--run_name is required when using --optuna")
+
+        from functools import partial
+
+        from sign_language_segmentation.hpo import load_search_space, run_study
+
+        search_space, metric = load_search_space(
+            path=args.optuna,
+            skip_architecture=args.finetune_from is not None,
+        )
+
+        study = run_study(
+            train_fn=partial(train, monitor_metric=metric),
+            search_space=search_space,
+            n_trials=args.optuna_trials,
+            metric_name=metric,
+            wandb_entity=args.wandb_entity,
+            wandb_project=args.wandb_project,
+            no_wandb=args.no_wandb,
+        )
+
+        print("\n--- Optuna results ---")
+        print(f"Best trial: {study.best_trial.number}")
+        print(f"Best {metric}: {study.best_value:.4f}")
+        print(f"Best params: {study.best_params}")
+    else:
+        train()


### PR DESCRIPTION
## Summary
Depends on #15 (`refactor/data-layer`).

- Enable W&B logging by default with `--wandb_entity`/`--wandb_project` args and full hyperparameter tracking
- Add `--lr_scale_backbone` for discriminative fine-tuning (lower LR for CNN + transformer backbone, full LR for classification heads)
- Add Optuna HPO via `--optuna <yaml>` with a dedicated `hpo.py` module
  - YAML search space split into `architecture` and `training` sections — architecture params auto-skipped when fine-tuning
  - `monitor_metric` configurable in the YAML
  - W&B callback (`as_multirun`) for per-trial logging, trials named `<run_name>-t0`, `<run_name>-t1`, etc. (`--run_name` required for Optuna)
  - Pruning callback to kill unpromising trials early
- Refactor training loop into `train(overrides, monitor_metric)` function
- Move `wandb` from dev to main deps, add `optuna`, `optuna-integration`, `pyyaml`

## Test plan
- [x] `ruff check .` passes
- [x] 37 tests pass
- [x] Training runs successfully (verified 1 epoch, validation_hm_iou 0.617)

🤖 Generated with [Claude Code](https://claude.com/claude-code)