### PR TITLE
refactor: dataset registry for multi-dataset training

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install ".[dev,server]" --extra-index-url https://download.pytorch.org/whl/cpu
+        run: uv pip install ".[dev,server,train]" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Test Code
         run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dgs = [
     "sign_language_datasets",
     "tensorflow<2.19",
     "tensorflow-datasets==4.9.2",
+    "pyarrow",  # transitive: tensorflow-datasets needs it at import time
     "lxml",
     "webvtt-py",  # transitive: sign_language_datasets eagerly imports mediapi_skel
 ]

--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -37,6 +37,8 @@ parser.add_argument('--optuna_trials', type=int, default=50,
                     help='number of Optuna trials (default: 50)')
 
 # Data
+parser.add_argument('--datasets', type=str, default='dgs',
+                    help='comma-separated dataset names to train on (e.g. dgs,platform)')
 parser.add_argument('--corpus', default='/mnt/nas/GCS/sign-external-datasets/dgs-corpus')
 parser.add_argument('--poses', default='/mnt/nas/GCS/sign-mediapipe-holistic-poses')
 parser.add_argument('--velocity', action='store_true', default=True,

--- a/sign_language_segmentation/datasets/__init__.py
+++ b/sign_language_segmentation/datasets/__init__.py
@@ -1,13 +1,17 @@
 from sign_language_segmentation.datasets.common import (
+    DATASET_REGISTRY,
     BaseSegmentationDataset,
-    DatasetType,
     Split,
+    build_datasets,
     collate_fn,
+    register_dataset,
 )
 
 __all__ = [
     "BaseSegmentationDataset",
+    "DATASET_REGISTRY",
     "Split",
-    "DatasetType",
+    "build_datasets",
     "collate_fn",
+    "register_dataset",
 ]

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from argparse import Namespace
 import hashlib
 import random
 from enum import StrEnum
@@ -7,7 +10,7 @@ import numpy as np
 import torch
 from pose_format import Pose
 from torch import Tensor
-from torch.utils.data import Dataset
+from torch.utils.data import ConcatDataset, Dataset
 
 from sign_language_segmentation.utils.bio import BIO, create_bio, create_bio_from_times
 from sign_language_segmentation.utils.pose import compute_velocity, preprocess_pose
@@ -19,8 +22,45 @@ class Split(StrEnum):
     TEST = "test"
 
 
-class DatasetType(StrEnum):
-    DGS = "dgs"
+# -- dataset registry ----------------------------------------------------------
+
+DATASET_REGISTRY: dict[str, type[BaseSegmentationDataset]] = {}
+
+
+def register_dataset(name: str, cls: type[BaseSegmentationDataset]) -> None:
+    """register a dataset class under *name* so build_datasets can find it."""
+    DATASET_REGISTRY[name] = cls
+
+
+def _ensure_datasets_registered() -> None:
+    """lazily import known dataset packages to trigger registration."""
+    if DATASET_REGISTRY:
+        return
+    # importing the modules registers the datasets
+    import sign_language_segmentation.datasets.dgs  # noqa: F401
+
+
+def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) -> Dataset:
+    """build one or more datasets from a comma-separated *names* string.
+
+    Each name must be registered via register_dataset(). Dataset-specific
+    args are pulled from *args* inside each class's from_args classmethod.
+    augment_kwargs (num_frames, velocity, fps_aug, ...) are forwarded as-is.
+    """
+    _ensure_datasets_registered()
+
+    dataset_names = [n.strip() for n in names.split(",")]
+    datasets: list[Dataset] = []
+    for name in dataset_names:
+        if name not in DATASET_REGISTRY:
+            available = ", ".join(sorted(DATASET_REGISTRY.keys()))
+            raise ValueError(f"Unknown dataset: {name!r}. Available: {available}")
+        cls = DATASET_REGISTRY[name]
+        datasets.append(cls.from_args(split=split, args=args, **augment_kwargs))
+
+    if len(datasets) == 1:
+        return datasets[0]
+    return ConcatDataset(datasets)
 
 
 def md5sum(file_path: str) -> str:
@@ -50,6 +90,12 @@ class BaseSegmentationDataset(Dataset, ABC):
 
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None: ...
+
+    @classmethod
+    @abstractmethod
+    def from_args(cls, split: Split, args: Namespace, **augment_kwargs) -> BaseSegmentationDataset:
+        """construct from a parsed argument namespace + shared augment kwargs."""
+        ...
 
     @abstractmethod
     def get_split_manifest(self) -> dict: ...

--- a/sign_language_segmentation/datasets/dgs/__init__.py
+++ b/sign_language_segmentation/datasets/dgs/__init__.py
@@ -1,3 +1,6 @@
+from sign_language_segmentation.datasets.common import register_dataset
 from sign_language_segmentation.datasets.dgs.dataset import DGSSegmentationDataset
+
+register_dataset("dgs", DGSSegmentationDataset)
 
 __all__ = ["DGSSegmentationDataset"]

--- a/sign_language_segmentation/datasets/dgs/dataset.py
+++ b/sign_language_segmentation/datasets/dgs/dataset.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from argparse import Namespace
 import json
 import os
 
@@ -154,6 +157,16 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                 json.dump(cache, f)
         except OSError:
             pass
+
+    @classmethod
+    def from_args(cls, split: Split, args: Namespace, **augment_kwargs) -> DGSSegmentationDataset:
+        return cls(
+            corpus_dir=args.corpus,
+            poses_dir=args.poses,
+            split=split,
+            target_fps=getattr(args, "target_fps", None),
+            **augment_kwargs,
+        )
 
     def get_split_manifest(self) -> dict:
         """return manifest of video IDs per split for reproducibility tracking."""

--- a/sign_language_segmentation/evaluate.py
+++ b/sign_language_segmentation/evaluate.py
@@ -8,8 +8,7 @@ import argparse
 import torch
 from torch.utils.data import DataLoader
 
-from sign_language_segmentation.datasets.dgs.dataset import DGSSegmentationDataset
-from sign_language_segmentation.datasets.common import collate_fn
+from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
 from sign_language_segmentation.utils.bio import BIO
 from sign_language_segmentation.metrics import (
     frame_f1, likeliest_probs_to_segments,
@@ -70,6 +69,8 @@ def evaluate_model(model, dataloader, device, seg_fn=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--checkpoint", required=True, help="Path to model checkpoint")
+    parser.add_argument("--datasets", type=str, default="dgs",
+                        help="comma-separated dataset names (e.g. dgs,platform)")
     parser.add_argument("--corpus", default="/mnt/nas/GCS/sign-external-datasets/dgs-corpus")
     parser.add_argument("--poses", default="/mnt/nas/GCS/sign-mediapipe-holistic-poses")
     parser.add_argument("--split", choices=["dev", "test"], default="test")
@@ -93,12 +94,11 @@ if __name__ == "__main__":
     fps_aug = getattr(model.hparams, 'fps_aug', False)
     velocity = getattr(model.hparams, 'velocity', True)
 
-    dataset = DGSSegmentationDataset(
-        corpus_dir=eval_args.corpus,
-        poses_dir=eval_args.poses,
-        split=eval_args.split,
+    dataset = build_datasets(
+        names=eval_args.datasets,
+        split=Split(eval_args.split),
+        args=eval_args,
         num_frames=999999,
-        target_fps=eval_args.target_fps,
         fps_aug=fps_aug,
         velocity=velocity,
     )
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     results = evaluate_model(model, dataloader, eval_args.device, seg_fn=seg_fn)
 
     print(f"\n{'='*50}")
-    print(f"Evaluation on {eval_args.split} set")
+    print(f"Evaluation on {eval_args.datasets} {eval_args.split} set")
     print(f"{'='*50}")
     print(f"Sign Frame F1:     {results['sign_frame_f1']:.4f}")
     print(f"Sign IoU:          {results['sign_IoU']:.4f}")

--- a/sign_language_segmentation/tests/test_common.py
+++ b/sign_language_segmentation/tests/test_common.py
@@ -7,12 +7,14 @@ import pytest
 import torch
 
 from sign_language_segmentation.datasets.common import (
+    DATASET_REGISTRY,
     BaseSegmentationDataset,
-    DatasetType,
     Split,
+    build_datasets,
     collate_fn,
     load_and_augment,
     md5sum,
+    register_dataset,
 )
 from sign_language_segmentation.utils.bio import BIO
 
@@ -27,14 +29,30 @@ class TestEnums:
         assert Split.DEV == "dev"
         assert Split.TEST == "test"
 
-    def test_dataset_type_values(self):
-        assert DatasetType.DGS == "dgs"
-
     def test_split_from_string(self):
         assert Split("train") is Split.TRAIN
 
-    def test_dataset_type_from_string(self):
-        assert DatasetType("dgs") is DatasetType.DGS
+
+class TestDatasetRegistry:
+    def test_dgs_registered(self):
+        from sign_language_segmentation.datasets.dgs import DGSSegmentationDataset
+        assert DATASET_REGISTRY["dgs"] is DGSSegmentationDataset
+
+    def test_register_custom_dataset(self):
+        class _Dummy(BaseSegmentationDataset):
+            def __init__(self): ...
+            @classmethod
+            def from_args(cls, split, args, **kw): return cls()
+            def get_split_manifest(self): return {}
+
+        register_dataset("_test_dummy", _Dummy)
+        assert DATASET_REGISTRY["_test_dummy"] is _Dummy
+        del DATASET_REGISTRY["_test_dummy"]
+
+    def test_build_datasets_unknown_name(self):
+        import argparse
+        with pytest.raises(ValueError, match="Unknown dataset"):
+            build_datasets("nonexistent", Split.TRAIN, argparse.Namespace())
 
 
 # -- md5sum -------------------------------------------------------------------
@@ -275,6 +293,10 @@ class TestBaseSegmentationDataset:
                 self.fps_aug = False
                 self.frame_dropout = 0.0
                 self.body_part_dropout = 0.0
+
+            @classmethod
+            def from_args(cls, split, args, **kw):
+                return cls()
 
             def get_split_manifest(self) -> dict:
                 return {"dataset": "dummy"}

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -6,30 +6,44 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.loggers import WandbLogger
-from torch.utils.data import DataLoader
+from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from sign_language_segmentation.args import args
-from sign_language_segmentation.datasets.dgs.dataset import DGSSegmentationDataset
-from sign_language_segmentation.datasets.common import Split, collate_fn
+from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
 from sign_language_segmentation.model.model import PoseTaggingModel
+
+
+def _collect_split_manifest(dataset: Dataset, dataset_names: str) -> dict:
+    """collect split manifest from dataset(s)."""
+    manifests: list[dict] = []
+    if isinstance(dataset, ConcatDataset):
+        for ds in dataset.datasets:
+            if hasattr(ds, "get_split_manifest"):
+                manifests.append(ds.get_split_manifest())
+    elif hasattr(dataset, "get_split_manifest"):
+        manifests.append(dataset.get_split_manifest())
+    return {
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+        "datasets": dataset_names,
+        "manifests": manifests,
+    }
 
 
 def get_dataloader(
     split: Split,
+    dataset_names: str,
     batch_size: int | None = None,
     num_frames: int | None = None,
     persistent_workers: bool = True,
 ) -> DataLoader:
-    dataset = DGSSegmentationDataset(
-        corpus_dir=args.corpus,
-        poses_dir=args.poses,
-        split=split,
+    augment_kwargs = dict(
         num_frames=num_frames if num_frames is not None else args.num_frames,
         velocity=args.velocity,
         fps_aug=args.fps_aug,
         frame_dropout=args.frame_dropout,
         body_part_dropout=args.body_part_dropout if split == Split.TRAIN else 0.0,
     )
+    dataset = build_datasets(names=dataset_names, split=split, args=args, **augment_kwargs)
     return DataLoader(
         dataset,
         batch_size=batch_size or args.batch_size,
@@ -80,8 +94,8 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
         effective_args = {**vars(args), **overrides}
         logger.log_hyperparams(effective_args)
 
-    train_loader = get_dataloader(Split.TRAIN, batch_size=_get("batch_size"))
-    validation_loader = get_dataloader(Split.DEV, batch_size=1)
+    train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, batch_size=_get("batch_size"))
+    validation_loader = get_dataloader(Split.DEV, dataset_names=args.datasets, batch_size=1)
 
     example_datum = train_loader.dataset[0]
     pose_joints, pose_dims = example_datum["pose"].shape[1:3]
@@ -120,10 +134,9 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
     model_dir.mkdir(parents=True, exist_ok=True)
 
     # write split manifest
-    manifest = {
-        "created_at": datetime.now(tz=timezone.utc).isoformat(),
-        "dataset": "dgs",
-    }
+    manifest = _collect_split_manifest(train_loader.dataset, args.datasets)
+    val_manifest = _collect_split_manifest(validation_loader.dataset, args.datasets)
+    manifest["manifests"].extend(val_manifest["manifests"])
     manifest_path = model_dir / "split_manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")


### PR DESCRIPTION
## Summary
- Add `DATASET_REGISTRY` + `register_dataset()` + `build_datasets()` to `common.py` so new datasets can be added without modifying `train.py` or `evaluate.py`
- Each dataset implements `from_args(split, args, **augment_kwargs)` classmethod and registers itself on import
- `--datasets` CLI arg accepts comma-separated names (e.g. `dgs,platform`), replacing the `DatasetType` enum and `--dataset` choices
- Shared dataset construction path between `train.py` and `evaluate.py` (removes duplication flagged in #17)

## Adding a new dataset
1. Subclass `BaseSegmentationDataset`, implement `from_args` + `get_split_manifest`
2. Call `register_dataset("name", YourClass)` in `__init__.py`
3. Add the import to `_ensure_datasets_registered()` in `common.py`

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` passes (38 tests)
- [x] Smoke test: 1-epoch training with `--datasets dgs` (validation_hm_iou: 0.617)

Addresses review feedback from #17.