### PR TITLE
refactor: shared get_dataloader between train and evaluate

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master, main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master, main, nagish ]
 
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master, main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master, main, nagish ]
 
 
 jobs:

--- a/sign_language_segmentation/datasets/__init__.py
+++ b/sign_language_segmentation/datasets/__init__.py
@@ -4,6 +4,7 @@ from sign_language_segmentation.datasets.common import (
     Split,
     build_datasets,
     collate_fn,
+    get_dataloader,
     register_dataset,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "Split",
     "build_datasets",
     "collate_fn",
+    "get_dataloader",
     "register_dataset",
 ]

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from pose_format import Pose
 from torch import Tensor
-from torch.utils.data import ConcatDataset, Dataset
+from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from sign_language_segmentation.utils.bio import BIO, create_bio, create_bio_from_times
 from sign_language_segmentation.utils.pose import compute_velocity, preprocess_pose
@@ -62,6 +62,41 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     if len(datasets) == 1:
         return datasets[0]
     return ConcatDataset(datasets)
+
+
+def get_dataloader(
+    split: Split,
+    dataset_names: str,
+    args: Namespace,
+    batch_size: int | None = None,
+    num_frames: int | None = None,
+    persistent_workers: bool = True,
+    **augment_overrides,
+) -> DataLoader:
+    """build a DataLoader for one or more datasets.
+
+    augment kwargs default to values from *args* but can be overridden
+    via **augment_overrides (e.g. fps_aug=False for evaluation).
+    """
+    augment_kwargs = dict(
+        num_frames=num_frames if num_frames is not None else getattr(args, "num_frames", 999999),
+        velocity=getattr(args, "velocity", True),
+        fps_aug=getattr(args, "fps_aug", True),
+        frame_dropout=getattr(args, "frame_dropout", 0.0),
+        body_part_dropout=getattr(args, "body_part_dropout", 0.0) if split == Split.TRAIN else 0.0,
+    )
+    augment_kwargs.update(augment_overrides)
+    dataset = build_datasets(names=dataset_names, split=split, args=args, **augment_kwargs)
+    return DataLoader(
+        dataset,
+        batch_size=batch_size or getattr(args, "batch_size", 1),
+        shuffle=(split == Split.TRAIN),
+        collate_fn=collate_fn,
+        num_workers=8,
+        persistent_workers=persistent_workers,
+        prefetch_factor=4 if persistent_workers else 2,
+        pin_memory=True,
+    )
 
 
 def md5sum(file_path: str) -> str:

--- a/sign_language_segmentation/evaluate.py
+++ b/sign_language_segmentation/evaluate.py
@@ -6,9 +6,8 @@ matching the evaluation protocol from the EMNLP 2023 paper.
 import argparse
 
 import torch
-from torch.utils.data import DataLoader
 
-from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
+from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.utils.bio import BIO
 from sign_language_segmentation.metrics import (
     frame_f1, likeliest_probs_to_segments,
@@ -96,15 +95,16 @@ if __name__ == "__main__":
     fps_aug = getattr(model.hparams, 'fps_aug', False)
     velocity = getattr(model.hparams, 'velocity', True)
 
-    dataset = build_datasets(
-        names=eval_args.datasets,
+    dataloader = get_dataloader(
         split=Split(eval_args.split),
+        dataset_names=eval_args.datasets,
         args=eval_args,
+        batch_size=1,
         num_frames=999999,
+        persistent_workers=False,
         fps_aug=fps_aug,
         velocity=velocity,
     )
-    dataloader = DataLoader(dataset, batch_size=1, collate_fn=collate_fn)
 
     def seg_fn(lp):
         segs = likeliest_probs_to_segments(lp)

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -108,6 +108,8 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     # write split manifest
     manifest = _collect_split_manifest(train_loader.dataset, args.datasets)
+    val_manifest = _collect_split_manifest(validation_loader.dataset, args.datasets)
+    manifest["manifests"].extend(val_manifest["manifests"])
     manifest_path = model_dir / "split_manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -9,7 +9,7 @@ from pytorch_lightning.loggers import WandbLogger
 from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from sign_language_segmentation.args import args
-from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
+from sign_language_segmentation.datasets.common import Split, collate_fn, get_dataloader
 from sign_language_segmentation.model.model import PoseTaggingModel
 
 
@@ -27,33 +27,6 @@ def _collect_split_manifest(dataset: Dataset, dataset_names: str) -> dict:
         "datasets": dataset_names,
         "manifests": manifests,
     }
-
-
-def get_dataloader(
-    split: Split,
-    dataset_names: str,
-    batch_size: int | None = None,
-    num_frames: int | None = None,
-    persistent_workers: bool = True,
-) -> DataLoader:
-    augment_kwargs = dict(
-        num_frames=num_frames if num_frames is not None else args.num_frames,
-        velocity=args.velocity,
-        fps_aug=args.fps_aug,
-        frame_dropout=args.frame_dropout,
-        body_part_dropout=args.body_part_dropout if split == Split.TRAIN else 0.0,
-    )
-    dataset = build_datasets(names=dataset_names, split=split, args=args, **augment_kwargs)
-    return DataLoader(
-        dataset,
-        batch_size=batch_size or args.batch_size,
-        shuffle=(split == Split.TRAIN),
-        collate_fn=collate_fn,
-        num_workers=8,
-        persistent_workers=persistent_workers,
-        prefetch_factor=4 if persistent_workers else 2,
-        pin_memory=True,
-    )
 
 
 _DEFAULT_MONITOR_METRIC = "validation_hm_iou"
@@ -94,8 +67,8 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
         effective_args = {**vars(args), **overrides}
         logger.log_hyperparams(effective_args)
 
-    train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, batch_size=_get("batch_size"))
-    validation_loader = get_dataloader(Split.DEV, dataset_names=args.datasets, batch_size=1)
+    train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, args=args, batch_size=_get("batch_size"))
+    validation_loader = get_dataloader(Split.DEV, dataset_names=args.datasets, args=args, batch_size=1)
 
     example_datum = train_loader.dataset[0]
     pose_joints, pose_dims = example_datum["pose"].shape[1:3]
@@ -135,8 +108,6 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     # write split manifest
     manifest = _collect_split_manifest(train_loader.dataset, args.datasets)
-    val_manifest = _collect_split_manifest(validation_loader.dataset, args.datasets)
-    manifest["manifests"].extend(val_manifest["manifests"])
     manifest_path = model_dir / "split_manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")


### PR DESCRIPTION
## Summary
- Move `get_dataloader` from `train.py` to `datasets/common.py` with explicit `args` parameter
- `evaluate.py` uses shared `get_dataloader` instead of manual `build_datasets` + `DataLoader`
- CI: run lint and test workflows on PRs targeting `nagish` branch

## Changed files
- `datasets/common.py` — add `get_dataloader()` with `**augment_overrides` support
- `train.py` — remove local `get_dataloader`, import from common
- `evaluate.py` — use `get_dataloader` instead of manual construction
- `datasets/__init__.py` — export `get_dataloader`
- `.github/workflows/test.yaml` / `lint.yaml` — add `nagish` to PR branch triggers

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` passes (61 tests)