### PR TITLE
refactor: consolidate split logic in base class

### DIFF
--- a/sign_language_segmentation/datasets/__init__.py
+++ b/sign_language_segmentation/datasets/__init__.py
@@ -2,18 +2,22 @@ from sign_language_segmentation.datasets.common import (
     DATASET_REGISTRY,
     BaseSegmentationDataset,
     Split,
+    assign_split,
     build_datasets,
     collate_fn,
     get_dataloader,
     register_dataset,
+    split_bucket,
 )
 
 __all__ = [
     "BaseSegmentationDataset",
     "DATASET_REGISTRY",
     "Split",
+    "assign_split",
     "build_datasets",
     "collate_fn",
     "get_dataloader",
     "register_dataset",
+    "split_bucket",
 ]

--- a/sign_language_segmentation/datasets/annotation_platform/dataset.py
+++ b/sign_language_segmentation/datasets/annotation_platform/dataset.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from argparse import Namespace
-import hashlib
 import json
 import os
 
-from sign_language_segmentation.datasets.common import BaseSegmentationDataset, Split
+from sign_language_segmentation.datasets.common import BaseSegmentationDataset, Split, assign_split
 
 
 class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
@@ -14,6 +13,8 @@ class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
     Reads a local annotations_cache.json produced by sync.py, resolves pose files,
     and produces the same output format as DGSSegmentationDataset.
     """
+
+    dataset_name = "annotation_platform"
 
     def __init__(
         self,
@@ -38,9 +39,10 @@ class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
         self.frame_dropout = frame_dropout
         self.body_part_dropout = body_part_dropout
         self.split_seed = split_seed
-        self.dev_ratio = dev_ratio
-        self.test_ratio = test_ratio
         self.quality_percentile = quality_percentile
+
+        self._init_split_tracking()
+        self.items = []
 
         with open(annotations_path) as f:
             cache = json.load(f)
@@ -78,29 +80,9 @@ class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
             keep_count = max(1, int(len(all_videos) * quality_percentile))
             all_videos = all_videos[:keep_count]
 
-        # deterministic split by video ID
-        train_threshold = int((1.0 - dev_ratio - test_ratio) * 1000)
-        dev_threshold = int((1.0 - test_ratio) * 1000)
-
-        self.items: list[dict] = []
-        self._all_split_ids: dict[str, list[str]] = {
-            Split.TRAIN: [],
-            Split.DEV: [],
-            Split.TEST: [],
-        }
-
         for video in all_videos:
-            bucket = _split_bucket(video_id=video["id"], seed=split_seed)
-            if bucket < train_threshold:
-                video_split = Split.TRAIN
-            elif bucket < dev_threshold:
-                video_split = Split.DEV
-            else:
-                video_split = Split.TEST
-
-            self._all_split_ids[video_split].append(video["id"])
-            if video_split == split:
-                self.items.append(video)
+            video_split = assign_split(video["id"], split_seed=split_seed, dev_ratio=dev_ratio, test_ratio=test_ratio)
+            self._track_and_filter(video["id"], video_split, video)
 
         print(
             f"AnnotationPlatformSegmentationDataset({split}): "
@@ -123,17 +105,6 @@ class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
         )
 
     def get_split_manifest(self) -> dict:
-        """return manifest of video IDs per split for reproducibility tracking."""
-        return {
-            "dataset": "annotation_platform",
-            "split_seed": self.split_seed,
-            "quality_percentile": self.quality_percentile,
-            "splits": {
-                split.value: sorted(ids) for split, ids in self._all_split_ids.items()
-            },
-        }
-
-def _split_bucket(video_id: str, seed: int) -> int:
-    """deterministic hash-based split assignment. returns 0-999."""
-    h = hashlib.sha256(f"{video_id}_{seed}".encode()).hexdigest()
-    return int(h, 16) % 1000
+        manifest = super().get_split_manifest()
+        manifest["quality_percentile"] = self.quality_percentile
+        return manifest

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -108,13 +108,43 @@ def md5sum(file_path: str) -> str:
     return h.hexdigest()
 
 
+def split_bucket(video_id: str, seed: int) -> int:
+    """deterministic hash-based split assignment. returns 0-999."""
+    h = hashlib.sha256(f"{video_id}_{seed}".encode()).hexdigest()
+    return int(h, 16) % 1000
+
+
+def assign_split(
+    video_id: str,
+    split_seed: int,
+    dev_ratio: float = 0.1,
+    test_ratio: float = 0.1,
+) -> Split:
+    """assign a split to a video ID based on deterministic hashing."""
+    train_threshold = int((1.0 - dev_ratio - test_ratio) * 1000)
+    dev_threshold = int((1.0 - test_ratio) * 1000)
+    bucket = split_bucket(video_id=video_id, seed=split_seed)
+    if bucket < train_threshold:
+        return Split.TRAIN
+    if bucket < dev_threshold:
+        return Split.DEV
+    return Split.TEST
+
+
 class BaseSegmentationDataset(Dataset, ABC):
     """base class for segmentation datasets.
 
     Subclasses must populate self.items in __init__ — a list of dicts with keys:
     id, pose_path, fps, total_frames, glosses (sign spans), sentences (phrase spans).
     All span times must be in milliseconds.
+
+    Split tracking via _init_split_tracking / _track_and_filter / get_split_manifest.
+    Default get_split_manifest uses split_seed (for hash-based splits); subclasses
+    with fixed splits (e.g. DGS) can override get_split_manifest.
     """
+
+    # dataset name used in manifests — subclasses should set this
+    dataset_name: str = "base"
 
     items: list[dict]
     split: Split
@@ -123,9 +153,24 @@ class BaseSegmentationDataset(Dataset, ABC):
     fps_aug: bool
     frame_dropout: float
     body_part_dropout: float
+    _all_split_ids: dict[str, list[str]]
 
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None: ...
+
+    def _init_split_tracking(self) -> None:
+        """initialize split tracking — call at the start of subclass __init__."""
+        self._all_split_ids = {
+            Split.TRAIN: [],
+            Split.DEV: [],
+            Split.TEST: [],
+        }
+
+    def _track_and_filter(self, video_id: str, video_split: Split, item: dict) -> None:
+        """track a video's split assignment and append to self.items if it matches."""
+        self._all_split_ids[video_split].append(video_id)
+        if video_split == self.split:
+            self.items.append(item)
 
     @classmethod
     @abstractmethod
@@ -133,8 +178,15 @@ class BaseSegmentationDataset(Dataset, ABC):
         """construct from a parsed argument namespace + shared augment kwargs."""
         ...
 
-    @abstractmethod
-    def get_split_manifest(self) -> dict: ...
+    def get_split_manifest(self) -> dict:
+        """return manifest of video IDs per split for reproducibility tracking."""
+        return {
+            "dataset": self.dataset_name,
+            "split_seed": self.split_seed,
+            "splits": {
+                s.value: sorted(ids) for s, ids in self._all_split_ids.items()
+            },
+        }
 
     def __len__(self) -> int:
         return len(self.items)

--- a/sign_language_segmentation/datasets/dgs/dataset.py
+++ b/sign_language_segmentation/datasets/dgs/dataset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from argparse import Namespace
 import json
-import os
+from pathlib import Path
 
 from pose_format import Pose
 from pose_format.pose_body import EmptyPoseBody
@@ -19,16 +19,17 @@ from sign_language_segmentation.datasets.common import BaseSegmentationDataset, 
 EXCLUDED_IDS: set[str] = {"1289910", "1245887", "1289868", "1246064", "1584617"}
 
 
-def is_joke(corpus_dir: str, doc_id: str) -> bool:
-    cmdi_path = os.path.join(corpus_dir, "videos", doc_id, "data.cmdi")
-    if not os.path.exists(cmdi_path):
+def is_joke(corpus_dir: Path, doc_id: str) -> bool:
+    cmdi_path = corpus_dir / "videos" / doc_id / "data.cmdi"
+    if not cmdi_path.exists():
         return False
-    with open(cmdi_path, "r") as f:
-        return "<cmdp:Task>Joke</cmdp:Task>" in f.read()
+    return "<cmdp:Task>Joke</cmdp:Task>" in cmdi_path.read_text()
 
 
 class DGSSegmentationDataset(BaseSegmentationDataset):
     """reads DGS corpus poses on the fly with efficient partial reading."""
+
+    dataset_name = "dgs"
 
     def __init__(
         self,
@@ -44,8 +45,8 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
         splits_path: str | None = None,
         cache_path: str | None = None,
     ):
-        self.corpus_dir = corpus_dir
-        self.poses_dir = poses_dir
+        self.corpus_dir = Path(corpus_dir)
+        self.poses_dir = Path(poses_dir)
         self.split = split
         self.num_frames = num_frames
         self.velocity = velocity
@@ -55,48 +56,47 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
         self.body_part_dropout = body_part_dropout
 
         if splits_path is None:
-            splits_path = os.path.join(os.path.dirname(__file__), "splits.json")
-        with open(splits_path) as f:
-            splits = json.load(f)
-
+            splits_path = str(Path(__file__).parent / "splits.json")
+        self.splits_path = splits_path
+        splits = json.loads(Path(splits_path).read_text())
         dev_ids = set(splits["dev"])
         test_ids = set(splits["test"])
 
-        if cache_path is None:
-            cache_path = os.path.join(corpus_dir, ".segmentation_cache.json")
+        self._init_split_tracking()
+        self.items = []
 
-        self.items: list[dict] = []
-        cache = self._load_cache(cache_path)
+        cache_file = Path(cache_path) if cache_path else self.corpus_dir / ".segmentation_cache.json"
+        cache = self._load_cache(cache_file)
         cache_dirty = False
 
-        videos_dir = os.path.join(corpus_dir, "videos")
+        videos_dir = self.corpus_dir / "videos"
         doc_ids = sorted(
-            d for d in os.listdir(videos_dir)
-            if os.path.isdir(os.path.join(videos_dir, d))
+            d.name for d in videos_dir.iterdir() if d.is_dir()
         )
 
         for doc_id in doc_ids:
-            if doc_id in EXCLUDED_IDS or is_joke(corpus_dir, doc_id):
+            if doc_id in EXCLUDED_IDS or is_joke(self.corpus_dir, doc_id):
                 continue
 
-            if split == Split.DEV and doc_id not in dev_ids:
-                continue
-            if split == Split.TEST and doc_id not in test_ids:
-                continue
-            if split == Split.TRAIN and (doc_id in dev_ids or doc_id in test_ids):
+            # fixed split from splits.json (research-standard split)
+            if doc_id in dev_ids:
+                doc_split = Split.DEV
+            elif doc_id in test_ids:
+                doc_split = Split.TEST
+            else:
+                doc_split = Split.TRAIN
+
+            eaf_path = videos_dir / doc_id / "data.eaf"
+            if not eaf_path.exists() or eaf_path.stat().st_size < 10000:
                 continue
 
-            eaf_path = os.path.join(videos_dir, doc_id, "data.eaf")
-            if not os.path.exists(eaf_path) or os.path.getsize(eaf_path) < 10000:
-                continue
-
-            sentences = list(get_elan_sentences(eaf_path))
+            sentences = list(get_elan_sentences(str(eaf_path)))
             if not sentences:
                 continue
 
             for person in ("a", "b"):
-                video_path = os.path.join(videos_dir, doc_id, f"video_{person}.mp4")
-                if not os.path.exists(video_path):
+                video_path = videos_dir / doc_id / f"video_{person}.mp4"
+                if not video_path.exists():
                     continue
 
                 cache_key = f"{doc_id}_{person}"
@@ -106,9 +106,9 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                     fps = cache[cache_key]["fps"]
                     total_frames = cache[cache_key]["total_frames"]
                 else:
-                    video_hash = md5sum(video_path)
-                    pose_path = os.path.join(poses_dir, f"{video_hash}.pose")
-                    if not os.path.exists(pose_path):
+                    video_hash = md5sum(str(video_path))
+                    pose_path = self.poses_dir / f"{video_hash}.pose"
+                    if not pose_path.exists():
                         continue
                     with open(pose_path, "rb") as f:
                         meta_pose = Pose.read(f, pose_body=EmptyPoseBody)
@@ -117,8 +117,8 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                     cache[cache_key] = {"hash": video_hash, "fps": fps, "total_frames": total_frames}
                     cache_dirty = True
 
-                pose_path = os.path.join(poses_dir, f"{video_hash}.pose")
-                if not os.path.exists(pose_path):
+                pose_path = self.poses_dir / f"{video_hash}.pose"
+                if not pose_path.exists():
                     continue
 
                 person_sentences = [
@@ -131,9 +131,9 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                 all_glosses = [g for s in person_sentences for g in s["glosses"]]
                 sentence_spans = [{"start": s["start"], "end": s["end"]} for s in person_sentences]
 
-                self.items.append({
+                self._track_and_filter(cache_key, doc_split, {
                     "id": cache_key,
-                    "pose_path": pose_path,
+                    "pose_path": str(pose_path),
                     "fps": fps,
                     "total_frames": total_frames,
                     "glosses": all_glosses,
@@ -141,20 +141,33 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                 })
 
         if cache_dirty:
-            self._save_cache(cache_path, cache)
+            self._save_cache(cache_file, cache)
 
-        print(f"DGSSegmentationDataset({split}): {len(self.items)} videos")
+        print(
+            f"DGSSegmentationDataset({split}): "
+            f"{len(self.items)} videos "
+            f"(train={len(self._all_split_ids[Split.TRAIN])}, "
+            f"dev={len(self._all_split_ids[Split.DEV])}, "
+            f"test={len(self._all_split_ids[Split.TEST])})"
+        )
 
-    def _load_cache(self, path: str) -> dict:
-        if os.path.exists(path):
-            with open(path) as f:
-                return json.load(f)
+    def get_split_manifest(self) -> dict:
+        return {
+            "dataset": self.dataset_name,
+            "splits_path": self.splits_path,
+            "splits": {
+                s.value: sorted(ids) for s, ids in self._all_split_ids.items()
+            },
+        }
+
+    def _load_cache(self, path: Path) -> dict:
+        if path.exists():
+            return json.loads(path.read_text())
         return {}
 
-    def _save_cache(self, path: str, cache: dict) -> None:
+    def _save_cache(self, path: Path, cache: dict) -> None:
         try:
-            with open(path, "w") as f:
-                json.dump(cache, f)
+            path.write_text(json.dumps(cache))
         except OSError:
             pass
 
@@ -167,12 +180,3 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
             target_fps=getattr(args, "target_fps", None),
             **augment_kwargs,
         )
-
-    def get_split_manifest(self) -> dict:
-        """return manifest of video IDs per split for reproducibility tracking."""
-        return {
-            "dataset": "dgs",
-            "split": self.split.value,
-            "video_ids": [item["id"] for item in self.items],
-        }
-

--- a/sign_language_segmentation/tests/test_annotation_platform.py
+++ b/sign_language_segmentation/tests/test_annotation_platform.py
@@ -8,14 +8,13 @@ import pytest
 
 from sign_language_segmentation.datasets.annotation_platform.dataset import (
     AnnotationPlatformSegmentationDataset,
-    _split_bucket,
 )
 from sign_language_segmentation.datasets.annotation_platform.sync import (
     _gcs_url_to_local,
     convex_query,
     fetch_ontology_class_map,
 )
-from sign_language_segmentation.datasets.common import Split
+from sign_language_segmentation.datasets.common import Split, split_bucket as _split_bucket
 
 EXAMPLE_POSE = Path(__file__).parent / "example.pose"
 

--- a/sign_language_segmentation/tests/test_common.py
+++ b/sign_language_segmentation/tests/test_common.py
@@ -43,7 +43,6 @@ class TestDatasetRegistry:
             def __init__(self): ...
             @classmethod
             def from_args(cls, split, args, **kw): return cls()
-            def get_split_manifest(self): return {}
 
         register_dataset("_test_dummy", _Dummy)
         assert DATASET_REGISTRY["_test_dummy"] is _Dummy
@@ -285,6 +284,8 @@ class TestBaseSegmentationDataset:
 
     def test_subclass_inherits_len_and_getitem(self):
         class DummyDataset(BaseSegmentationDataset):
+            dataset_name = "dummy"
+
             def __init__(self):
                 self.items = [{"id": "test"}]
                 self.split = Split.TRAIN
@@ -293,14 +294,15 @@ class TestBaseSegmentationDataset:
                 self.fps_aug = False
                 self.frame_dropout = 0.0
                 self.body_part_dropout = 0.0
+                self.split_seed = 42
+                self._init_split_tracking()
 
             @classmethod
             def from_args(cls, split, args, **kw):
                 return cls()
 
-            def get_split_manifest(self) -> dict:
-                return {"dataset": "dummy"}
-
         ds = DummyDataset()
         assert len(ds) == 1
-        assert ds.get_split_manifest() == {"dataset": "dummy"}
+        manifest = ds.get_split_manifest()
+        assert manifest["dataset"] == "dummy"
+        assert manifest["split_seed"] == 42

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -6,10 +6,10 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.loggers import WandbLogger
-from torch.utils.data import ConcatDataset, DataLoader, Dataset
+from torch.utils.data import ConcatDataset, Dataset
 
 from sign_language_segmentation.args import args
-from sign_language_segmentation.datasets.common import Split, collate_fn, get_dataloader
+from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.model.model import PoseTaggingModel
 
 
@@ -108,8 +108,6 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     # write split manifest
     manifest = _collect_split_manifest(train_loader.dataset, args.datasets)
-    val_manifest = _collect_split_manifest(validation_loader.dataset, args.datasets)
-    manifest["manifests"].extend(val_manifest["manifests"])
     manifest_path = model_dir / "split_manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")


### PR DESCRIPTION
## Summary
- Add `split_bucket()` and `assign_split()` to `common.py` — deterministic hash-based split assignment
- Add `_init_split_tracking()`, `_track_and_filter()`, `get_split_manifest()` to `BaseSegmentationDataset` — removes duplication across all dataset classes
- DGS: keep fixed `splits.json` (research-standard split), migrate to base class tracking infra and pathlib
- Platform: use `assign_split()` + base class helpers, remove local `_split_bucket`
- Remove unused `collate_fn`/`DataLoader` imports and duplicate manifest collection in `train.py`

Depends on #19.

## Changed files
- `datasets/common.py` — `split_bucket`, `assign_split`, base class split tracking
- `datasets/dgs/dataset.py` — use base class tracking while keeping fixed splits.json, migrate to pathlib
- `datasets/annotation_platform/dataset.py` — use `assign_split` + base class helpers
- `train.py` — remove unused imports and duplicate manifest
- `tests/` — update imports and dummy dataset

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` passes (61 tests)
- [x] 1-epoch DGS training smoke test — splits match original (545 train, 9 dev, 14 test)
- [x] 1-epoch dgs,platform training smoke test — both datasets load correctly