### PR TITLE
refactor: use .cache directory for dataset annotation caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ models/
 logs/
 lightning_logs/
 uv.lock
-annotations_cache.json
-video_map_cache.json
 run_hpo.sh
 *.pose
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ uv.lock
 annotations_cache.json
 video_map_cache.json
 run_hpo.sh
+*.pose
+.cache/

--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -41,9 +41,6 @@ parser.add_argument('--datasets', type=str, default='dgs',
                     help='comma-separated dataset names to train on (e.g. dgs,platform)')
 parser.add_argument('--corpus', default='/mnt/nas/GCS/sign-external-datasets/dgs-corpus')
 parser.add_argument('--poses', default='/mnt/nas/GCS/sign-mediapipe-holistic-poses')
-parser.add_argument('--annotations_path', type=str,
-                    default='sign_language_segmentation/datasets/annotation_platform/annotations_cache.json',
-                    help='path to annotations_cache.json for platform/combined datasets')
 parser.add_argument('--quality_percentile', type=float, default=1.0,
                     help='keep top X of platform annotations by quality score (1.0=all, 0.8=top 80%%)')
 parser.add_argument('--velocity', action='store_true', default=True,

--- a/sign_language_segmentation/datasets/annotation_platform/dataset.py
+++ b/sign_language_segmentation/datasets/annotation_platform/dataset.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 import json
 import os
 
-from sign_language_segmentation.datasets.common import BaseSegmentationDataset, Split, assign_split
+from sign_language_segmentation.datasets.common import CACHE_DIR, BaseSegmentationDataset, Split, assign_split
 
 
 class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
@@ -94,10 +94,13 @@ class AnnotationPlatformSegmentationDataset(BaseSegmentationDataset):
 
     @classmethod
     def from_args(cls, split: Split, args: Namespace, **augment_kwargs) -> AnnotationPlatformSegmentationDataset:
-        if not getattr(args, "annotations_path", None):
-            raise ValueError("--annotations_path required for platform dataset")
+        annotations_path = CACHE_DIR / cls.dataset_name / "annotations_cache.json"
+        if not annotations_path.exists():
+            raise FileNotFoundError(
+                f"annotations cache not found at {annotations_path} — run the sync script first"
+            )
         return cls(
-            annotations_path=args.annotations_path,
+            annotations_path=str(annotations_path),
             poses_dir=args.poses,
             split=split,
             quality_percentile=getattr(args, "quality_percentile", 1.0),

--- a/sign_language_segmentation/datasets/annotation_platform/sync.py
+++ b/sign_language_segmentation/datasets/annotation_platform/sync.py
@@ -23,11 +23,11 @@ import httpx
 from pose_format import Pose
 from pose_format.pose_body import EmptyPoseBody
 
-from sign_language_segmentation.datasets.common import md5sum
+from sign_language_segmentation.datasets.common import CACHE_DIR, md5sum
 
-_PACKAGE_DIR = Path(__file__).resolve().parent
-_DEFAULT_ANNOTATIONS_CACHE = _PACKAGE_DIR / "annotations_cache.json"
-_DEFAULT_VIDEO_MAP_CACHE = _PACKAGE_DIR / "video_map_cache.json"
+_DATASET_CACHE_DIR = CACHE_DIR / "annotation_platform"
+_DEFAULT_ANNOTATIONS_CACHE = _DATASET_CACHE_DIR / "annotations_cache.json"
+_DEFAULT_VIDEO_MAP_CACHE = _DATASET_CACHE_DIR / "video_map_cache.json"
 
 
 def _build_auth_header(token: str) -> str:

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from argparse import Namespace
 import hashlib
+from pathlib import Path
 import random
 from enum import StrEnum
 
@@ -14,6 +15,9 @@ from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from sign_language_segmentation.utils.bio import BIO, create_bio, create_bio_from_times
 from sign_language_segmentation.utils.pose import compute_velocity, preprocess_pose
+
+# project-level cache directory — each dataset stores its annotations_cache.json under .cache/{dataset_name}/
+CACHE_DIR = Path(__file__).resolve().parents[2] / ".cache"
 
 
 class Split(StrEnum):

--- a/sign_language_segmentation/datasets/dgs/dataset.py
+++ b/sign_language_segmentation/datasets/dgs/dataset.py
@@ -14,7 +14,7 @@ if not hasattr(_tfds_resource, "get_dl_dirname"):
 
 from sign_language_datasets.datasets.dgs_corpus.dgs_utils import get_elan_sentences
 
-from sign_language_segmentation.datasets.common import BaseSegmentationDataset, Split, md5sum
+from sign_language_segmentation.datasets.common import CACHE_DIR, BaseSegmentationDataset, Split, md5sum
 
 EXCLUDED_IDS: set[str] = {"1289910", "1245887", "1289868", "1246064", "1584617"}
 
@@ -64,6 +64,11 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
 
         self._init_split_tracking()
         self.items = []
+
+        if cache_path is None:
+            dgs_cache_dir = CACHE_DIR / "dgs"
+            dgs_cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_path = str(dgs_cache_dir / "segmentation_cache.json")
 
         cache_file = Path(cache_path) if cache_path else self.corpus_dir / ".segmentation_cache.json"
         cache = self._load_cache(cache_file)

--- a/sign_language_segmentation/evaluate.py
+++ b/sign_language_segmentation/evaluate.py
@@ -72,8 +72,6 @@ if __name__ == "__main__":
                         help="comma-separated dataset names (e.g. dgs,platform)")
     parser.add_argument("--corpus", default="/mnt/nas/GCS/sign-external-datasets/dgs-corpus")
     parser.add_argument("--poses", default="/mnt/nas/GCS/sign-mediapipe-holistic-poses")
-    parser.add_argument("--annotations_path", type=str,
-                        default="sign_language_segmentation/datasets/annotation_platform/annotations_cache.json")
     parser.add_argument("--split", choices=["dev", "test"], default="test")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--target_fps", type=float, default=None,


### PR DESCRIPTION
## Summary
- Add a project-level `.cache/` directory convention — each dataset stores its cache files under `.cache/{dataset_name}/`
- Introduce `CACHE_DIR` constant in `common.py`, used by dataset `from_args` and sync scripts to resolve cache paths
- Remove `--annotations_path` CLI arg from `args.py` and `evaluate.py` (no longer needed)
- Update `annotation_platform/sync.py` default output to write to `.cache/annotation_platform/`
- Move DGS `segmentation_cache.json` from the corpus directory to `.cache/dgs/`

## Test plan
- [x] 61 unit tests pass
- [x] 1-epoch training on `dgs` alone
- [x] 1-epoch training on `platform` alone
- [x] 1-epoch training on `dgs,platform` combined