### PR TITLE
feat: support "all" keyword for --datasets argument

### DIFF
--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -37,8 +37,8 @@ parser.add_argument('--optuna_trials', type=int, default=50,
                     help='number of Optuna trials (default: 50)')
 
 # Data
-parser.add_argument('--datasets', type=str, default='dgs',
-                    help='comma-separated dataset names to train on (e.g. dgs,platform)')
+parser.add_argument('--datasets', type=str, default='all',
+                    help='comma-separated dataset names to train on (e.g. dgs,platform), or "all" for every registered dataset')
 parser.add_argument('--corpus', default='/mnt/nas/GCS/sign-external-datasets/dgs-corpus')
 parser.add_argument('--poses', default='/mnt/nas/GCS/sign-mediapipe-holistic-poses')
 parser.add_argument('--quality_percentile', type=float, default=1.0,

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -54,7 +54,7 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     """
     _ensure_datasets_registered()
 
-    dataset_names = [n.strip() for n in names.split(",")]
+    dataset_names = sorted(DATASET_REGISTRY.keys()) if names == "all" else [n.strip() for n in names.split(",")]
     datasets: list[Dataset] = []
     for name in dataset_names:
         if name not in DATASET_REGISTRY:


### PR DESCRIPTION
## Summary
- `--datasets all` now expands to every registered dataset in the registry
- Default changed from `dgs` to `all` so training uses all available datasets out of the box
- Comma-separated syntax (`--datasets dgs,platform`) still works as before

## Test plan
- [x] Run `python -m sign_language_segmentation.train` (no `--datasets` flag) — should use all registered datasets
- [x] Run with `--datasets dgs` — should use only DGS
- [x] Run with `--datasets dgs,platform` — should use both

🤖 Generated with [Claude Code](https://claude.com/claude-code)