### PR TITLE
feat: publish utils — conversion, versioning, model card

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ where = ["."]
 include = ["sign_language_segmentation*"]
 
 [tool.setuptools.package-data]
-sign_language_segmentation = ["**/*.json", "**/*.safetensors", "**/*.yaml"]
+sign_language_segmentation = ["**/*.json", "**/*.safetensors", "**/*.yaml", "**/*.md"]
 
 [tool.pytest.ini_options]
 addopts = "-v"

--- a/sign_language_segmentation/publish/model_card_template.md
+++ b/sign_language_segmentation/publish/model_card_template.md
@@ -35,5 +35,6 @@ Jointly trained on sign (gloss) and phrase (sentence) BIO tagging.
 
 ```bash
 pip install sign-language-segmentation
+export HF_MODEL_REPO={{repo_id}} HF_MODEL_REVISION={{tag}}
 pose_to_segments --pose input.pose --elan output.eaf
 ```

--- a/sign_language_segmentation/publish/model_card_template.md
+++ b/sign_language_segmentation/publish/model_card_template.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - sign-language
+  - segmentation
+  - pose
+  - pytorch
+  - pytorch-lightning
+library_name: pytorch
+pipeline_tag: other
+{{model_index}}
+---
+
+# Sign Language Segmentation
+
+CNN-medium-attn model with RoPE for sign language segmentation.
+Jointly trained on sign (gloss) and phrase (sentence) BIO tagging.
+
+**Published:** {{published_at}}
+**Tag:** `{{tag}}`
+**Regression status:** {{regression_status}}
+
+## Architecture
+
+{{architecture_rows}}
+
+{{eval_section}}
+
+## Training Config
+
+{{training_rows}}
+
+{{dataset_section}}
+
+## Usage
+
+```bash
+pip install sign-language-segmentation
+pose_to_segments --pose input.pose --elan output.eaf
+```

--- a/sign_language_segmentation/publish/utils.py
+++ b/sign_language_segmentation/publish/utils.py
@@ -1,0 +1,216 @@
+"""Pure helpers for model publishing: conversion, versioning, model card rendering."""
+
+import json
+import re
+from datetime import datetime, UTC
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file as save_safetensors
+
+
+def convert_to_safetensors(checkpoint_path: str, output_dir: Path) -> dict:
+    """Convert .ckpt to safetensors + config.json. Returns hyper_parameters dict."""
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+
+    sd_bf16 = {k: v.to(torch.bfloat16) if v.is_floating_point() else v for k, v in ckpt["state_dict"].items()}
+    save_safetensors(tensors=sd_bf16, filename=str(output_dir / "model.safetensors"))
+
+    config = ckpt["hyper_parameters"]
+    config = {k: list(v) if isinstance(v, tuple) else v for k, v in config.items()}
+    with open(output_dir / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+
+    return config
+
+
+def find_split_manifest(checkpoint_path: str) -> dict | None:
+    """Look for split_manifest.json in the same directory as the checkpoint."""
+    manifest_path = Path(checkpoint_path).parent / "split_manifest.json"
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            return json.load(f)
+    return None
+
+
+def _parse_version(tag_name: str) -> tuple[int, ...] | None:
+    """Parse a vYYYY.MM.DD[.N] tag. Returns None if not a version tag."""
+    version_re = re.compile(r"^v(\d{4})\.(\d{1,2})\.(\d{1,2})(?:\.(\d+))?$")
+    m = version_re.match(tag_name)
+    if not m:
+        return None
+    parts = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    if m.group(4) is not None:
+        return (*parts, int(m.group(4)))
+    return parts
+
+
+def get_latest_version(repo_id: str) -> str | None:
+    """Get the latest date-based version tag from the HF repo. Returns None if no version tags exist."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    try:
+        refs = api.list_repo_refs(repo_id=repo_id)
+    except Exception:
+        return None
+    versions = []
+    for tag in refs.tags:
+        parsed = _parse_version(tag.name)
+        if parsed:
+            versions.append((parsed, tag.name))
+    if not versions:
+        return None
+    versions.sort()
+    return versions[-1][1]
+
+
+def get_next_version(repo_id: str) -> str:
+    """Determine the next version tag based on today's date (vYYYY.MM.DD).
+
+    If a tag for today already exists, appends a suffix (vYYYY.MM.DD.1, .2, ...).
+    """
+    today = datetime.now(tz=UTC)
+    base = f"v{today.year}.{today.month}.{today.day}"
+
+    latest = get_latest_version(repo_id=repo_id)
+    if latest is None:
+        return base
+
+    parsed = _parse_version(latest)
+    year, month, day = parsed[0], parsed[1], parsed[2]
+    if (year, month, day) != (today.year, today.month, today.day):
+        return base
+
+    # same day — increment suffix
+    suffix = parsed[3] + 1 if len(parsed) == 4 else 1
+    return f"{base}.{suffix}"
+
+
+def _get_test_metrics(eval_results: dict) -> dict:
+    """Extract flat test metrics from eval_results (handles both nested and legacy flat format)."""
+    if "combined" in eval_results:
+        return eval_results["combined"].get("test", {})
+    # single dataset
+    for key, val in eval_results.items():
+        if isinstance(val, dict) and "test" in val:
+            return val["test"]
+    # legacy flat format (no nesting)
+    return eval_results
+
+
+def _build_config_table(config: dict, keys: list[str]) -> str:
+    """Render config keys as a single-row transposed table (keys as columns)."""
+    present = [(k, config[k]) for k in keys if k in config]
+    if not present:
+        return ""
+    header = "| " + " | ".join(k for k, _ in present) + " |"
+    separator = "| " + " | ".join("---" for _ in present) + " |"
+    values = "| " + " | ".join(str(v) for _, v in present) + " |"
+    return f"{header}\n{separator}\n{values}"
+
+
+def _build_model_index(eval_results: dict) -> str:
+    test_metrics = _get_test_metrics(eval_results)
+    lines = [
+        "model-index:",
+        "  - name: sign-language-segmentation",
+        "    results:",
+        "      - task:",
+        "          type: other",
+        "          name: Sign Language Segmentation",
+        "        metrics:",
+    ]
+    for key, value in test_metrics.items():
+        display_name = key.replace("_", " ").title()
+        lines.append(f"          - name: {display_name}")
+        lines.append(f"            type: {key}")
+        lines.append(f"            value: {value:.4f}")
+    return "\n".join(lines)
+
+
+def _build_eval_section(eval_results: dict) -> str:
+    metric_columns = [
+        ("sign_IoU", "Sign IoU"),
+        ("sentence_IoU", "Sentence IoU"),
+        ("hm_IoU", "HM IoU"),
+        ("sign_frame_f1", "Sign Frame F1"),
+        ("sign_segment_f1", "Sign Segment F1"),
+        ("sentence_frame_f1", "Sentence Frame F1"),
+        ("sentence_segment_f1", "Sentence Segment F1"),
+    ]
+    headers = ["Dataset", "Split"] + [display for _, display in metric_columns]
+    header_row = "| " + " | ".join(headers) + " |"
+    separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+
+    rows = []
+    # separate per-dataset entries from "combined"
+    ds_names = [k for k in eval_results if k != "combined" and isinstance(eval_results[k], dict)]
+    if "combined" in eval_results:
+        ds_names.append("combined")
+
+    for ds_name in ds_names:
+        splits = eval_results[ds_name]
+        if not isinstance(splits, dict) or "test" not in splits:
+            continue
+        is_combined = ds_name == "combined"
+        display_name = ds_name.replace("_", " ").title()
+        if is_combined:
+            display_name = f"**{display_name}**"
+
+        for i, split_name in enumerate(["dev", "test"]):
+            if split_name not in splits:
+                continue
+            metrics = splits[split_name]
+            name_cell = display_name if i == 0 else ""
+            split_cell = split_name
+            if is_combined:
+                split_cell = f"**{split_name}**"
+            values = [f"{metrics.get(key, 0):.4f}" for key, _ in metric_columns]
+            if is_combined:
+                values = [f"**{v}**" for v in values]
+            rows.append("| " + " | ".join([name_cell, split_cell] + values) + " |")
+
+    return f"## Evaluation Results\n\n{header_row}\n{separator}\n" + "\n".join(rows)
+
+
+def _build_dataset_section(split_manifest: dict) -> str:
+    datasets = split_manifest.get("datasets", "unknown")
+    created_at = split_manifest.get("created_at", "unknown")
+    return f"## Dataset\n\n- **Datasets:** {datasets}\n- **Created at:** {created_at}"
+
+
+def generate_model_card(
+    config: dict, eval_results: dict | None, regression_status: str, tag: str, split_manifest: dict | None
+) -> str:
+    """Generate a HuggingFace model card from template."""
+    template_path = Path(__file__).resolve().parent / "model_card_template.md"
+    template = template_path.read_text()
+
+    arch_keys = [
+        "hidden_dim",
+        "encoder_depth",
+        "attn_nhead",
+        "attn_ff_mult",
+        "attn_dropout",
+        "num_frames",
+        "pose_dims",
+        "num_classes",
+    ]
+    train_keys = ["learning_rate", "optimizer", "dice_loss_weight", "fps_aug", "frame_dropout"]
+
+    replacements = {
+        "{{published_at}}": datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC"),
+        "{{tag}}": tag,
+        "{{regression_status}}": regression_status,
+        "{{architecture_rows}}": _build_config_table(config=config, keys=arch_keys),
+        "{{training_rows}}": _build_config_table(config=config, keys=train_keys),
+        "{{model_index}}": _build_model_index(eval_results=eval_results) if eval_results else "",
+        "{{eval_section}}": _build_eval_section(eval_results=eval_results) if eval_results else "",
+        "{{dataset_section}}": _build_dataset_section(split_manifest=split_manifest) if split_manifest else "",
+    }
+
+    for placeholder, value in replacements.items():
+        template = template.replace(placeholder, value)
+
+    return template

--- a/sign_language_segmentation/publish/utils.py
+++ b/sign_language_segmentation/publish/utils.py
@@ -9,8 +9,22 @@ import torch
 from safetensors.torch import save_file as save_safetensors
 
 
+# display names for metrics used in both the YAML model-index and the markdown eval table.
+# keys are the raw metric keys emitted by evaluation; values are the human-readable labels.
+_METRIC_DISPLAY_NAMES: dict[str, str] = {
+    "sign_IoU": "Sign IoU",
+    "sentence_IoU": "Sentence IoU",
+    "hm_IoU": "HM IoU",
+    "sign_frame_f1": "Sign Frame F1",
+    "sign_segment_f1": "Sign Segment F1",
+    "sentence_frame_f1": "Sentence Frame F1",
+    "sentence_segment_f1": "Sentence Segment F1",
+}
+
+
 def convert_to_safetensors(checkpoint_path: str, output_dir: Path) -> dict:
     """Convert .ckpt to safetensors + config.json. Returns hyper_parameters dict."""
+    # Lightning .ckpt files carry hyper_parameters alongside weights; weights_only=True would reject them.
     ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
 
     sd_bf16 = {k: v.to(torch.bfloat16) if v.is_floating_point() else v for k, v in ckpt["state_dict"].items()}
@@ -48,12 +62,17 @@ def _parse_version(tag_name: str) -> tuple[int, ...] | None:
 def get_latest_version(repo_id: str) -> str | None:
     """Get the latest date-based version tag from the HF repo. Returns None if no version tags exist."""
     from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
 
     api = HfApi()
     try:
         refs = api.list_repo_refs(repo_id=repo_id)
-    except Exception:
-        return None
+    except HfHubHTTPError as e:
+        # catch HfHubHTTPError (not bare Exception) so auth/network errors surface;
+        # only 404 (repo not found — first publish) is legitimately "no versions".
+        if e.response.status_code == 404:
+            return None
+        raise
     versions = []
     for tag in refs.tags:
         parsed = _parse_version(tag.name)
@@ -122,7 +141,7 @@ def _build_model_index(eval_results: dict) -> str:
         "        metrics:",
     ]
     for key, value in test_metrics.items():
-        display_name = key.replace("_", " ").title()
+        display_name = _METRIC_DISPLAY_NAMES.get(key, key)
         lines.append(f"          - name: {display_name}")
         lines.append(f"            type: {key}")
         lines.append(f"            value: {value:.4f}")
@@ -130,16 +149,8 @@ def _build_model_index(eval_results: dict) -> str:
 
 
 def _build_eval_section(eval_results: dict) -> str:
-    metric_columns = [
-        ("sign_IoU", "Sign IoU"),
-        ("sentence_IoU", "Sentence IoU"),
-        ("hm_IoU", "HM IoU"),
-        ("sign_frame_f1", "Sign Frame F1"),
-        ("sign_segment_f1", "Sign Segment F1"),
-        ("sentence_frame_f1", "Sentence Frame F1"),
-        ("sentence_segment_f1", "Sentence Segment F1"),
-    ]
-    headers = ["Dataset", "Split"] + [display for _, display in metric_columns]
+    metric_keys = list(_METRIC_DISPLAY_NAMES.keys())
+    headers = ["Dataset", "Split"] + [_METRIC_DISPLAY_NAMES[k] for k in metric_keys]
     header_row = "| " + " | ".join(headers) + " |"
     separator = "| " + " | ".join(["---"] * len(headers)) + " |"
 
@@ -166,7 +177,7 @@ def _build_eval_section(eval_results: dict) -> str:
             split_cell = split_name
             if is_combined:
                 split_cell = f"**{split_name}**"
-            values = [f"{metrics.get(key, 0):.4f}" for key, _ in metric_columns]
+            values = [f"{metrics.get(key, 0):.4f}" for key in metric_keys]
             if is_combined:
                 values = [f"**{v}**" for v in values]
             rows.append("| " + " | ".join([name_cell, split_cell] + values) + " |")
@@ -181,7 +192,12 @@ def _build_dataset_section(split_manifest: dict) -> str:
 
 
 def generate_model_card(
-    config: dict, eval_results: dict | None, regression_status: str, tag: str, split_manifest: dict | None
+    config: dict,
+    eval_results: dict | None,
+    regression_status: str,
+    tag: str,
+    repo_id: str,
+    split_manifest: dict | None,
 ) -> str:
     """Generate a HuggingFace model card from template."""
     template_path = Path(__file__).resolve().parent / "model_card_template.md"
@@ -202,6 +218,7 @@ def generate_model_card(
     replacements = {
         "{{published_at}}": datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC"),
         "{{tag}}": tag,
+        "{{repo_id}}": repo_id,
         "{{regression_status}}": regression_status,
         "{{architecture_rows}}": _build_config_table(config=config, keys=arch_keys),
         "{{training_rows}}": _build_config_table(config=config, keys=train_keys),

--- a/sign_language_segmentation/tests/test_publish_utils.py
+++ b/sign_language_segmentation/tests/test_publish_utils.py
@@ -1,0 +1,284 @@
+"""Unit tests for publish/utils.py pure helpers."""
+
+from datetime import datetime, UTC
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from sign_language_segmentation.publish.utils import (
+    _build_config_table,
+    _build_dataset_section,
+    _build_eval_section,
+    _build_model_index,
+    _get_test_metrics,
+    _parse_version,
+    find_split_manifest,
+    generate_model_card,
+    get_latest_version,
+    get_next_version,
+)
+
+
+class TestParseVersion:
+    def test_ymd_returns_3_tuple(self):
+        assert _parse_version("v2026.4.20") == (2026, 4, 20)
+
+    def test_ymd_with_suffix_returns_4_tuple(self):
+        assert _parse_version("v2026.4.20.3") == (2026, 4, 20, 3)
+
+    def test_zero_padded_month_day(self):
+        assert _parse_version("v2026.04.20") == (2026, 4, 20)
+
+    def test_garbage_returns_none(self):
+        assert _parse_version("nope") is None
+        assert _parse_version("v") is None
+        assert _parse_version("v1.2") is None
+        assert _parse_version("") is None
+
+    def test_legacy_semver_returns_none(self):
+        # legacy vA.B.C style with single-digit parts matches the regex (vYYYY.MM.DD),
+        # but real semver like v1.0.0 happens to parse as (1,0,0) — that's fine because
+        # real tags will always be real dates. Only clearly non-numeric garbage returns None.
+        assert _parse_version("v1.0.abc") is None
+
+
+class TestGetLatestVersion:
+    def test_mixed_tags_picks_max(self):
+        with patch("sign_language_segmentation.publish.utils.HfApi", create=True) as _:
+            pass
+        mock_refs = SimpleNamespace(
+            tags=[
+                SimpleNamespace(name="v2026.1.1"),
+                SimpleNamespace(name="v2026.4.20"),
+                SimpleNamespace(name="weekly"),
+                SimpleNamespace(name="v2026.3.15.2"),
+                SimpleNamespace(name="release-v1"),
+            ]
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_no_version_tags_returns_none(self):
+        mock_refs = SimpleNamespace(tags=[SimpleNamespace(name="weekly"), SimpleNamespace(name="main")])
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") is None
+
+    def test_api_error_returns_none(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.side_effect = RuntimeError("401")
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") is None
+
+    def test_suffix_beats_base_same_day(self):
+        mock_refs = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.4.20"), SimpleNamespace(name="v2026.4.20.1")]
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") == "v2026.4.20.1"
+
+
+class TestGetNextVersion:
+    def _freeze_today(self, monkeypatch, y, m, d):
+        class FrozenDT:
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(y, m, d, tzinfo=tz or UTC)
+        monkeypatch.setattr("sign_language_segmentation.publish.utils.datetime", FrozenDT)
+
+    def test_no_baseline_returns_base(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: None
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_prior_date_returns_base(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.1.1"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_same_day_base_increments_to_1(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.4.20"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20.1"
+
+    def test_same_day_with_suffix_increments(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.4.20.1"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20.2"
+
+
+class TestFindSplitManifest:
+    def test_returns_none_when_missing(self, tmp_path):
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.touch()
+        assert find_split_manifest(checkpoint_path=str(ckpt)) is None
+
+    def test_loads_manifest_from_sibling(self, tmp_path):
+        (tmp_path / "split_manifest.json").write_text('{"datasets": "dgs", "created_at": "2026-01-01"}')
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.touch()
+        manifest = find_split_manifest(checkpoint_path=str(ckpt))
+        assert manifest == {"datasets": "dgs", "created_at": "2026-01-01"}
+
+
+class TestGetTestMetrics:
+    def test_combined_wins(self):
+        results = {
+            "ds_a": {"test": {"sign_IoU": 0.5}},
+            "combined": {"test": {"sign_IoU": 0.9}},
+        }
+        assert _get_test_metrics(results) == {"sign_IoU": 0.9}
+
+    def test_single_dataset_picks_first(self):
+        results = {"ds_a": {"test": {"sign_IoU": 0.5}}}
+        assert _get_test_metrics(results) == {"sign_IoU": 0.5}
+
+    def test_legacy_flat_returns_as_is(self):
+        results = {"sign_IoU": 0.5, "sentence_IoU": 0.6}
+        assert _get_test_metrics(results) == results
+
+
+class TestBuildConfigTable:
+    def test_empty_keys_returns_empty(self):
+        assert _build_config_table(config={"a": 1}, keys=[]) == ""
+
+    def test_no_matching_keys_returns_empty(self):
+        assert _build_config_table(config={"a": 1}, keys=["b", "c"]) == ""
+
+    def test_partial_match_renders_present_only(self):
+        out = _build_config_table(config={"a": 1, "c": 3}, keys=["a", "b", "c"])
+        assert "| a | c |" in out
+        assert "| 1 | 3 |" in out
+        assert "b" not in out
+
+    def test_tuple_value_stringified(self):
+        out = _build_config_table(config={"pose_dims": (75, 3)}, keys=["pose_dims"])
+        assert "(75, 3)" in out
+
+
+class TestBuildModelIndex:
+    def test_emits_yaml_fragment(self):
+        results = {"combined": {"test": {"sign_IoU": 0.8765, "sentence_IoU": 0.5}}}
+        out = _build_model_index(eval_results=results)
+        assert "model-index:" in out
+        assert "- name: Sign Iou" in out
+        assert "type: sign_IoU" in out
+        assert "value: 0.8765" in out
+        assert "value: 0.5000" in out
+
+    def test_formats_to_four_decimals(self):
+        results = {"combined": {"test": {"sign_IoU": 1.0 / 3.0}}}
+        out = _build_model_index(eval_results=results)
+        assert "value: 0.3333" in out
+
+
+class TestBuildEvalSection:
+    def test_per_dataset_and_combined(self):
+        results = {
+            "ds_a": {
+                "dev": {"sign_IoU": 0.5, "sentence_IoU": 0.4},
+                "test": {"sign_IoU": 0.55, "sentence_IoU": 0.45},
+            },
+            "combined": {
+                "dev": {"sign_IoU": 0.6, "sentence_IoU": 0.5},
+                "test": {"sign_IoU": 0.65, "sentence_IoU": 0.55},
+            },
+        }
+        out = _build_eval_section(eval_results=results)
+        assert "## Evaluation Results" in out
+        assert "Ds A" in out
+        assert "**Combined**" in out
+        assert "**test**" in out  # combined splits are bolded
+
+    def test_missing_metrics_default_to_zero(self):
+        results = {"ds_a": {"test": {"sign_IoU": 0.5}}}
+        out = _build_eval_section(eval_results=results)
+        assert "0.0000" in out  # for metrics absent from dict
+
+
+class TestBuildDatasetSection:
+    def test_renders_fields(self):
+        manifest = {"datasets": "dgs,platform", "created_at": "2026-04-20"}
+        out = _build_dataset_section(split_manifest=manifest)
+        assert "dgs,platform" in out
+        assert "2026-04-20" in out
+
+    def test_missing_fields_default_to_unknown(self):
+        out = _build_dataset_section(split_manifest={})
+        assert "unknown" in out
+
+
+class TestGenerateModelCard:
+    def _fixture_config(self):
+        return {
+            "hidden_dim": 128,
+            "encoder_depth": 4,
+            "attn_nhead": 8,
+            "attn_ff_mult": 4,
+            "attn_dropout": 0.1,
+            "num_frames": 1024,
+            "pose_dims": (75, 3),
+            "num_classes": 3,
+            "learning_rate": 1e-4,
+            "optimizer": "adam",
+            "dice_loss_weight": 0.5,
+            "fps_aug": True,
+            "frame_dropout": 0.1,
+        }
+
+    def _fixture_eval(self):
+        return {
+            "ds_a": {"dev": {"sign_IoU": 0.5}, "test": {"sign_IoU": 0.55}},
+            "combined": {"dev": {"sign_IoU": 0.6}, "test": {"sign_IoU": 0.65}},
+        }
+
+    def test_replaces_every_placeholder(self):
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=self._fixture_eval(),
+            regression_status="pass",
+            tag="v2026.4.20",
+            split_manifest={"datasets": "ds_a", "created_at": "2026-04-20"},
+        )
+        assert "{{" not in out
+        assert "}}" not in out
+        assert "v2026.4.20" in out
+        assert "pass" in out
+
+    def test_omits_optional_sections_when_missing(self):
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=None,
+            regression_status="no_baseline",
+            tag="v2026.4.20",
+            split_manifest=None,
+        )
+        assert "{{" not in out
+        assert "## Evaluation Results" not in out
+
+    def test_no_language_field_in_frontmatter(self):
+        # language: was dropped per review comment #2
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=None,
+            regression_status="pass",
+            tag="v2026.4.20",
+            split_manifest=None,
+        )
+        # frontmatter is the first `---...---` block
+        frontmatter = out.split("---", 2)[1]
+        assert "language:" not in frontmatter

--- a/sign_language_segmentation/tests/test_publish_utils.py
+++ b/sign_language_segmentation/tests/test_publish_utils.py
@@ -37,6 +37,7 @@ class TestParseVersion:
         assert _parse_version("") is None
 
     def test_legacy_semver_returns_none(self):
+        # YYYY.MM.DD regex requires a 4-digit year, so semver-style v1.0.0 won't match
         assert _parse_version("v1.0.0") is None
         assert _parse_version("v1.0.abc") is None
 

--- a/sign_language_segmentation/tests/test_publish_utils.py
+++ b/sign_language_segmentation/tests/test_publish_utils.py
@@ -37,9 +37,7 @@ class TestParseVersion:
         assert _parse_version("") is None
 
     def test_legacy_semver_returns_none(self):
-        # legacy vA.B.C style with single-digit parts matches the regex (vYYYY.MM.DD),
-        # but real semver like v1.0.0 happens to parse as (1,0,0) — that's fine because
-        # real tags will always be real dates. Only clearly non-numeric garbage returns None.
+        assert _parse_version("v1.0.0") is None
         assert _parse_version("v1.0.abc") is None
 
 
@@ -68,11 +66,31 @@ class TestGetLatestVersion:
         with patch("huggingface_hub.HfApi", return_value=mock_api):
             assert get_latest_version(repo_id="fake/repo") is None
 
-    def test_api_error_returns_none(self):
+    def _make_hf_http_error(self, status_code: int, msg: str):
+        # HfHubHTTPError's __init__ touches response.headers; build a rich enough mock
+        from huggingface_hub.utils import HfHubHTTPError
+        response = MagicMock()
+        response.status_code = status_code
+        response.headers = {}
+        return HfHubHTTPError(msg, response=response)
+
+    def test_404_returns_none(self):
+        # first-publish: repo doesn't exist yet on HF
+        err = self._make_hf_http_error(status_code=404, msg="Repo not found")
         mock_api = MagicMock()
-        mock_api.list_repo_refs.side_effect = RuntimeError("401")
+        mock_api.list_repo_refs.side_effect = err
         with patch("huggingface_hub.HfApi", return_value=mock_api):
             assert get_latest_version(repo_id="fake/repo") is None
+
+    def test_non_404_propagates(self):
+        # auth/network errors must surface — they're not "no versions", they're real failures
+        from huggingface_hub.utils import HfHubHTTPError
+        err = self._make_hf_http_error(status_code=401, msg="Unauthorized")
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.side_effect = err
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(HfHubHTTPError):
+                get_latest_version(repo_id="fake/repo")
 
     def test_suffix_beats_base_same_day(self):
         mock_refs = SimpleNamespace(
@@ -175,7 +193,7 @@ class TestBuildModelIndex:
         results = {"combined": {"test": {"sign_IoU": 0.8765, "sentence_IoU": 0.5}}}
         out = _build_model_index(eval_results=results)
         assert "model-index:" in out
-        assert "- name: Sign Iou" in out
+        assert "- name: Sign IoU" in out
         assert "type: sign_IoU" in out
         assert "value: 0.8765" in out
         assert "value: 0.5000" in out
@@ -252,12 +270,14 @@ class TestGenerateModelCard:
             eval_results=self._fixture_eval(),
             regression_status="pass",
             tag="v2026.4.20",
+            repo_id="test/repo",
             split_manifest={"datasets": "ds_a", "created_at": "2026-04-20"},
         )
         assert "{{" not in out
         assert "}}" not in out
         assert "v2026.4.20" in out
         assert "pass" in out
+        assert "test/repo" in out
 
     def test_omits_optional_sections_when_missing(self):
         out = generate_model_card(
@@ -265,6 +285,7 @@ class TestGenerateModelCard:
             eval_results=None,
             regression_status="no_baseline",
             tag="v2026.4.20",
+            repo_id="test/repo",
             split_manifest=None,
         )
         assert "{{" not in out
@@ -277,6 +298,7 @@ class TestGenerateModelCard:
             eval_results=None,
             regression_status="pass",
             tag="v2026.4.20",
+            repo_id="test/repo",
             split_manifest=None,
         )
         # frontmatter is the first `---...---` block


### PR DESCRIPTION
**Depends on:** #28 — [`feat/safetensors-runtime`](https://github.com/sign-language-processing/segmentation/tree/feat/safetensors-runtime)

## Summary

Second of a 5-PR stack (layers 1–4 split #22; layer 5 adds `--dry-run` on top). Adds the **pure, side-effect-light helpers** under `sign_language_segmentation/publish/` — conversion, versioning, model card generation. Evaluation, regression check, promotion, and the CLI orchestrator are intentionally held back for the later layers.

No new **required** dependencies. `get_latest_version` imports `huggingface_hub` lazily inside the function, so modules load fine without `[hf]` installed; tests mock `HfApi`. The `[hf]` extras group lands in PR #31.

## What's in

- `publish/__init__.py` — empty (re-exports arrive in PR #30).
- `publish/model_card_template.md` — HF model card template.
- `publish/utils.py` — only the following helpers:
  - `convert_to_safetensors` (.ckpt → bf16 safetensors + config.json)
  - `find_split_manifest`
  - `_parse_version` / `get_latest_version` / `get_next_version` — date-based `vYYYY.MM.DD[.N]`
  - `_get_test_metrics`, `_build_config_table`, `_build_model_index`, `_build_eval_section`, `_build_dataset_section`, `generate_model_card`
- `tests/test_publish_utils.py` — 32 new tests, all pure / HF-mocked.
- `pyproject.toml` — add `**/*.md` to `[tool.setuptools.package-data]` so the template ships with the package.

### Review-comment fix shipped in this layer
- **#2 hardcoded `language: dgs`** — dropped the field from the template frontmatter. The `model-index` block below already declares task type, and `{{dataset_section}}` covers dataset coverage. A test asserts the frontmatter no longer contains `language:`.
- **#3 `except Exception` too broad** — narrowed to `HfHubHTTPError`; only 404 (first-publish) returns `None`, auth/network errors raise. Tests split into `test_404_returns_none` and `test_non_404_propagates`.
- **#4 "Sign Iou" in YAML model-index** — extracted `_METRIC_DISPLAY_NAMES` constant shared by model-index and eval table; guarantees consistent labels + column order.
- **#5 missing `repo_id` in usage block** — plumbed through `generate_model_card`; template now emits `export HF_MODEL_REPO={{repo_id}} HF_MODEL_REVISION={{tag}}`.
- **#9 (partial) no tests for +385 lines** — 32 unit tests here; evaluation/regression/promote/integration tests land in the later layers.
- **`weights_only=False` rationale** — inline comment on `torch.load` explaining Lightning ckpts carry `hyper_parameters`.

## Stack

5-PR stack — layers 1–4 split #22, layer 5 adds `--dry-run`:

1. `feat/safetensors-runtime` → `nagish` (PR #28)
2. **This PR** → #28
3. `feat/publish-hf-ops-and-eval` → this PR (PR #31)
4. `feat/publish-cli` → #31 (PR #30)
5. `feat/publish-dry-run` → #30 (PR #32)

## Test plan

- [x] `uv run --extra dev pytest sign_language_segmentation/tests/test_publish_utils.py` — 32 passed
- [x] `uv run --extra dev pytest sign_language_segmentation/tests` — 93 passed
- [x] `get_latest_version` test covers mixed tags, no version tags, 404 vs non-404, and suffix-beats-base same-day ordering
- [x] `get_next_version` test covers no baseline, prior date, same-day base, same-day with suffix (with frozen datetime)
- [x] `generate_model_card` asserts no surviving `{{...}}` placeholders and no `language:` in frontmatter