### PR TITLE
feat: publish HF ops + evaluation helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 CONVEX_URL=
 CONVEX_AUTH_TOKEN=
 WAND_API_KEY=
+# for interacting with HF api
+HF_TOKEN=
+HF_MODEL_REPO=
+HF_MODEL_REVISION=
+# needed for sparks (HF cache files are owned by root and error is thrown)
+XDG_CACHE_HOME=

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install ".[dev,server,train]" --extra-index-url https://download.pytorch.org/whl/cpu
+        run: uv pip install ".[dev,server,train,hf]" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Test Code
         run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ server = [
     "Flask-Compress",
     "Flask-Caching",
 ]
+hf = [
+    "huggingface_hub>=0.20.0",
+]
 
 [tool.ruff]
 line-length = 120

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -36,7 +36,7 @@ def register_dataset(name: str, cls: type[BaseSegmentationDataset]) -> None:
     DATASET_REGISTRY[name] = cls
 
 
-def _ensure_datasets_registered() -> None:
+def ensure_datasets_registered() -> None:
     """lazily import known dataset packages to trigger registration."""
     if DATASET_REGISTRY:
         return
@@ -52,7 +52,7 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     args are pulled from *args* inside each class's from_args classmethod.
     augment_kwargs (num_frames, velocity, fps_aug, ...) are forwarded as-is.
     """
-    _ensure_datasets_registered()
+    ensure_datasets_registered()
 
     dataset_names = sorted(DATASET_REGISTRY.keys()) if names == "all" else [n.strip() for n in names.split(",")]
     datasets: list[Dataset] = []

--- a/sign_language_segmentation/publish/utils.py
+++ b/sign_language_segmentation/publish/utils.py
@@ -1,5 +1,6 @@
-"""Pure helpers for model publishing: conversion, versioning, model card rendering."""
+"""Utility functions for model publishing: conversion, evaluation, regression, model card."""
 
+import argparse
 import json
 import re
 from datetime import datetime, UTC
@@ -231,3 +232,170 @@ def generate_model_card(
         template = template.replace(placeholder, value)
 
     return template
+
+
+def _eval_single(model, datasets: str, split: str, eval_args, fps_aug: bool, velocity: bool, device: str) -> dict:
+    """Evaluate on a single dataset+split combination."""
+    from sign_language_segmentation.evaluate import evaluate_model
+    from sign_language_segmentation.datasets.common import Split, get_dataloader
+
+    dataloader = get_dataloader(
+        split=Split(split),
+        dataset_names=datasets,
+        args=eval_args,
+        batch_size=1,
+        num_frames=999999,
+        persistent_workers=False,
+        fps_aug=fps_aug,
+        velocity=velocity,
+    )
+    return evaluate_model(model=model, dataloader=dataloader, device=device)
+
+
+def run_evaluation(
+    checkpoint_path: str,
+    datasets: str,
+    corpus: str,
+    poses: str,
+    device: str,
+    split_manifest: dict | None = None,
+) -> dict:
+    """Run model evaluation on each dataset individually and combined, for dev and test.
+
+    Returns nested dict: {dataset_name: {split: {metric: value}}}.
+    Top-level keys include each individual dataset, plus "combined".
+    """
+    from sign_language_segmentation.datasets.common import DATASET_REGISTRY, ensure_datasets_registered
+    from sign_language_segmentation.model.model import PoseTaggingModel
+
+    model = PoseTaggingModel.load_from_checkpoint(checkpoint_path=checkpoint_path, map_location=device, strict=False)
+    model = model.to(device)
+
+    fps_aug = getattr(model.hparams, "fps_aug", False)
+    velocity = getattr(model.hparams, "velocity", True)
+
+    # extract quality_percentile from manifest if available
+    quality_percentile = 1.0
+    if split_manifest:
+        for m in split_manifest.get("manifests", []):
+            qp = m.get("quality_percentile")
+            if qp is not None:
+                quality_percentile = qp
+                break
+
+    eval_args = argparse.Namespace(
+        corpus=corpus,
+        poses=poses,
+        target_fps=None,
+        quality_percentile=quality_percentile,
+    )
+
+    ensure_datasets_registered()
+    dataset_names = sorted(DATASET_REGISTRY.keys()) if datasets == "all" else [d.strip() for d in datasets.split(",")]
+    splits = ["dev", "test"]
+    results = {}
+
+    # per-dataset evaluation
+    for ds_name in dataset_names:
+        results[ds_name] = {}
+        for s in splits:
+            print(f"  evaluating {ds_name} {s}...")
+            results[ds_name][s] = _eval_single(
+                model=model,
+                datasets=ds_name,
+                split=s,
+                eval_args=eval_args,
+                fps_aug=fps_aug,
+                velocity=velocity,
+                device=device,
+            )
+
+    # combined evaluation (only if multiple datasets)
+    if len(dataset_names) > 1:
+        results["combined"] = {}
+        for s in splits:
+            print(f"  evaluating combined {s}...")
+            results["combined"][s] = _eval_single(
+                model=model,
+                datasets=datasets,
+                split=s,
+                eval_args=eval_args,
+                fps_aug=fps_aug,
+                velocity=velocity,
+                device=device,
+            )
+
+    return results
+
+
+def check_regression(new_metrics: dict, repo_id: str, threshold: float) -> tuple[str, dict | None]:
+    """Compare new metrics against the latest tagged model.
+
+    Returns (status, baseline_metrics) where status is "pass", "fail", or "no_baseline".
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    latest_tag = get_latest_version(repo_id=repo_id)
+    if latest_tag is None:
+        print("No version tags found — skipping regression check")
+        return "no_baseline", None
+    try:
+        print(f"Comparing against latest tag: {latest_tag}")
+        baseline_path = api.hf_hub_download(
+            repo_id=repo_id,
+            filename="eval_results.json",
+            revision=latest_tag,
+        )
+        with open(baseline_path) as f:
+            prod_metrics = json.load(f)
+    except Exception:
+        print(f"Could not download eval_results.json from {latest_tag} — skipping regression check")
+        return "no_baseline", None
+
+    # extract flat test metrics for comparison
+    new_test = _get_test_metrics(new_metrics)
+    old_test = _get_test_metrics(prod_metrics)
+
+    # check key metrics for regression
+    regressions = []
+    for key in ("sign_IoU", "sentence_IoU"):
+        old_val = old_test.get(key, 0.0)
+        new_val = new_test.get(key, 0.0)
+        if new_val < old_val - threshold:
+            regressions.append(f"  {key}: {old_val:.4f} -> {new_val:.4f} (delta: {new_val - old_val:+.4f})")
+
+    # TODO: add slack notifications
+    if regressions:
+        print("REGRESSION DETECTED:")
+        for r in regressions:
+            print(r)
+        return "fail", prod_metrics
+
+    print("Regression check passed")
+    return "pass", prod_metrics
+
+
+def promote(repo_id: str, tag: str, revision: str) -> None:
+    """Tag a revision to mark it as promoted."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+
+    # resolve the revision to a commit sha
+    refs = api.list_repo_refs(repo_id=repo_id)
+    target_sha = None
+    for ref_tag in refs.tags:
+        if ref_tag.name == revision:
+            target_sha = ref_tag.target_commit
+            break
+    if target_sha is None:
+        for branch in refs.branches:
+            if branch.name == revision:
+                target_sha = branch.target_commit
+                break
+    if target_sha is None:
+        raise ValueError(f"Could not resolve revision {revision!r} to a commit on {repo_id}")
+
+    api.create_tag(repo_id=repo_id, tag=tag, revision=target_sha)
+    print(f"Promoted: tagged '{tag}' at {target_sha[:8]}")

--- a/sign_language_segmentation/publish/utils.py
+++ b/sign_language_segmentation/publish/utils.py
@@ -268,20 +268,23 @@ def run_evaluation(
     from sign_language_segmentation.datasets.common import DATASET_REGISTRY, ensure_datasets_registered
     from sign_language_segmentation.model.model import PoseTaggingModel
 
-    model = PoseTaggingModel.load_from_checkpoint(checkpoint_path=checkpoint_path, map_location=device, strict=False)
+    model = PoseTaggingModel.load_from_checkpoint(checkpoint_path=checkpoint_path, map_location=device)
     model = model.to(device)
 
-    fps_aug = getattr(model.hparams, "fps_aug", False)
+    # fall back to training defaults from args.py (both default to True there) when a legacy
+    # ckpt doesn't carry these in hparams — keeps eval consistent with how the model was trained.
+    fps_aug = getattr(model.hparams, "fps_aug", True)
     velocity = getattr(model.hparams, "velocity", True)
 
-    # extract quality_percentile from manifest if available
+    # extract quality_percentile from manifest if available; all per-dataset manifests
+    # must agree on this value — the eval pipeline only carries a single value downstream.
     quality_percentile = 1.0
     if split_manifest:
-        for m in split_manifest.get("manifests", []):
-            qp = m.get("quality_percentile")
-            if qp is not None:
-                quality_percentile = qp
-                break
+        percentiles = {m["quality_percentile"] for m in split_manifest.get("manifests", []) if "quality_percentile" in m}
+        if len(percentiles) > 1:
+            raise ValueError(f"inconsistent quality_percentile across manifests: {percentiles}")
+        if percentiles:
+            quality_percentile = percentiles.pop()
 
     eval_args = argparse.Namespace(
         corpus=corpus,
@@ -334,6 +337,7 @@ def check_regression(new_metrics: dict, repo_id: str, threshold: float) -> tuple
     Returns (status, baseline_metrics) where status is "pass", "fail", or "no_baseline".
     """
     from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
 
     api = HfApi()
     latest_tag = get_latest_version(repo_id=repo_id)
@@ -349,9 +353,12 @@ def check_regression(new_metrics: dict, repo_id: str, threshold: float) -> tuple
         )
         with open(baseline_path) as f:
             prod_metrics = json.load(f)
-    except Exception:
-        print(f"Could not download eval_results.json from {latest_tag} — skipping regression check")
-        return "no_baseline", None
+    except HfHubHTTPError as e:
+        # only a missing baseline file (404) is "no baseline"; auth/network errors must surface.
+        if e.response.status_code == 404:
+            print(f"No eval_results.json at {latest_tag} — skipping regression check")
+            return "no_baseline", None
+        raise
 
     # extract flat test metrics for comparison
     new_test = _get_test_metrics(new_metrics)
@@ -359,13 +366,12 @@ def check_regression(new_metrics: dict, repo_id: str, threshold: float) -> tuple
 
     # check key metrics for regression
     regressions = []
-    for key in ("sign_IoU", "sentence_IoU"):
+    for key in ("sign_IoU", "sentence_IoU", "hm_IoU"):
         old_val = old_test.get(key, 0.0)
         new_val = new_test.get(key, 0.0)
         if new_val < old_val - threshold:
             regressions.append(f"  {key}: {old_val:.4f} -> {new_val:.4f} (delta: {new_val - old_val:+.4f})")
 
-    # TODO: add slack notifications
     if regressions:
         print("REGRESSION DETECTED:")
         for r in regressions:

--- a/sign_language_segmentation/tests/test_publish_cli.py
+++ b/sign_language_segmentation/tests/test_publish_cli.py
@@ -1,0 +1,104 @@
+"""Tests for HF-facing publish helpers: regression check and promotion."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sign_language_segmentation.publish.utils import check_regression, promote
+
+
+class TestCheckRegression:
+    def test_no_baseline_when_no_tags(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(tags=[], branches=[])
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(new_metrics={}, repo_id="fake/repo", threshold=0.005)
+        assert status == "no_baseline"
+        assert baseline is None
+
+    def test_no_baseline_when_download_fails(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.side_effect = RuntimeError("404")
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics={"combined": {"test": {"sign_IoU": 0.8}}},
+                repo_id="fake/repo",
+                threshold=0.005,
+            )
+        assert status == "no_baseline"
+        assert baseline is None
+
+    def test_pass_when_within_threshold(self, tmp_path):
+        baseline_file = tmp_path / "eval_results.json"
+        baseline_file.write_text(
+            json.dumps({"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}})
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.return_value = str(baseline_file)
+        new_metrics = {"combined": {"test": {"sign_IoU": 0.798, "sentence_IoU": 0.70}}}
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics=new_metrics, repo_id="fake/repo", threshold=0.005
+            )
+        assert status == "pass"
+        assert baseline == {"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}}
+
+    def test_fail_when_beyond_threshold(self, tmp_path):
+        baseline_file = tmp_path / "eval_results.json"
+        baseline_file.write_text(
+            json.dumps({"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}})
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.return_value = str(baseline_file)
+        new_metrics = {"combined": {"test": {"sign_IoU": 0.75, "sentence_IoU": 0.70}}}
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics=new_metrics, repo_id="fake/repo", threshold=0.005
+            )
+        assert status == "fail"
+        assert baseline is not None
+
+
+class TestPromote:
+    def test_tag_found_uses_tag_commit(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="weekly", target_commit="abc12345deadbeef")],
+            branches=[],
+        )
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            promote(repo_id="fake/repo", tag="v2026.4.20", revision="weekly")
+        mock_api.create_tag.assert_called_once_with(
+            repo_id="fake/repo", tag="v2026.4.20", revision="abc12345deadbeef"
+        )
+
+    def test_branch_found_uses_branch_commit(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[],
+            branches=[SimpleNamespace(name="weekly", target_commit="feedface00000000")],
+        )
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            promote(repo_id="fake/repo", tag="v2026.4.20", revision="weekly")
+        mock_api.create_tag.assert_called_once_with(
+            repo_id="fake/repo", tag="v2026.4.20", revision="feedface00000000"
+        )
+
+    def test_raises_when_unresolved(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(tags=[], branches=[])
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(ValueError, match="Could not resolve revision"):
+                promote(repo_id="fake/repo", tag="v2026.4.20", revision="nonexistent")
+        mock_api.create_tag.assert_not_called()

--- a/sign_language_segmentation/tests/test_publish_hf_ops.py
+++ b/sign_language_segmentation/tests/test_publish_hf_ops.py
@@ -18,12 +18,20 @@ class TestCheckRegression:
         assert status == "no_baseline"
         assert baseline is None
 
-    def test_no_baseline_when_download_fails(self):
+    def _make_hf_http_error(self, status_code: int, msg: str):
+        from huggingface_hub.utils import HfHubHTTPError
+        response = MagicMock()
+        response.status_code = status_code
+        response.headers = {}
+        return HfHubHTTPError(msg, response=response)
+
+    def test_no_baseline_when_download_404s(self):
+        # tag exists but eval_results.json was never uploaded — legitimate "no baseline"
         mock_api = MagicMock()
         mock_api.list_repo_refs.return_value = SimpleNamespace(
             tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
         )
-        mock_api.hf_hub_download.side_effect = RuntimeError("404")
+        mock_api.hf_hub_download.side_effect = self._make_hf_http_error(status_code=404, msg="File not found")
         with patch("huggingface_hub.HfApi", return_value=mock_api):
             status, baseline = check_regression(
                 new_metrics={"combined": {"test": {"sign_IoU": 0.8}}},
@@ -32,6 +40,22 @@ class TestCheckRegression:
             )
         assert status == "no_baseline"
         assert baseline is None
+
+    def test_non_404_download_error_propagates(self):
+        # auth/network errors are real failures, not "no baseline"
+        from huggingface_hub.utils import HfHubHTTPError
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.side_effect = self._make_hf_http_error(status_code=401, msg="Unauthorized")
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(HfHubHTTPError):
+                check_regression(
+                    new_metrics={"combined": {"test": {"sign_IoU": 0.8}}},
+                    repo_id="fake/repo",
+                    threshold=0.005,
+                )
 
     def test_pass_when_within_threshold(self, tmp_path):
         baseline_file = tmp_path / "eval_results.json"


### PR DESCRIPTION
**Depends on:** #29 — [`feat/publish-utils-and-card`](https://github.com/sign-language-processing/segmentation/tree/feat/publish-utils-and-card)

## Summary

Third of a 5-PR stack (layers 1–4 split #22; layer 5 adds `--dry-run` on top). Adds the **HF-facing helpers and evaluation plumbing** — everything side-effectful in the publish pipeline. No CLI entry point here; the orchestrator lands in the follow-up (PR #30).

- `publish/utils.py`: append `_eval_single`, `run_evaluation`, `check_regression`, `promote`.
  - `run_evaluation` uses `argparse.Namespace` instead of an ad-hoc class and imports `ensure_datasets_registered` as a public name.
  - `promote` raises `ValueError` when a revision can't be resolved to a commit, instead of silently passing the ref string through to `create_tag`.
- `datasets/common.py`: rename `_ensure_datasets_registered` → `ensure_datasets_registered` (public API).
- `pyproject.toml`: add `[hf]` optional group (`huggingface_hub>=0.20.0`).
- `.env.example`: append HF section (`HF_TOKEN`, `HF_MODEL_REPO`, `HF_MODEL_REVISION`, `XDG_CACHE_HOME`).

### Review-comment fixes in this layer

| # | Fix |
|---|-----|
| #4 | `_ensure_datasets_registered` → public `ensure_datasets_registered` |
| #5 | `class EvalArgs: pass` → `argparse.Namespace(...)` |
| #7 | `promote()` raises `ValueError` on unresolved revision |

(Fixes #1 and #6 live in `publish.py` and land with the CLI in PR #30.)

### Polish from post-review round

- **`except Exception` → `HfHubHTTPError`** in `check_regression` baseline download (same pattern as #29's `get_latest_version`): only 404 returns `no_baseline`; auth/network errors raise. New test `test_non_404_download_error_propagates` locks this in.
- **Dropped `strict=False`** on `PoseTaggingModel.load_from_checkpoint` — silent partial-load on ckpt key drift was a landmine for future checkpoint format changes.
- **Aligned hparam fallbacks** — `fps_aug` and `velocity` defaults now match `args.py` training defaults (both `True`) with a comment; prior values (`fps_aug=False`) silently diverged from training config for legacy ckpts.
- **`quality_percentile` equality assertion** — raise `ValueError` when per-dataset manifests disagree (previously "first wins" silently).
- **`hm_IoU` added to regression checks** — `hm_IoU` regressions no longer slip through; still TODO to share this list with the metric-names constant in #29.
- **Dropped dangling `# TODO: add slack notifications`** — noise, not a commitment.
- **Renamed `tests/test_publish_cli.py` → `tests/test_publish_hf_ops.py`** — tests cover HF ops, not the CLI; CLI-orchestrator tests land in #30 with their own `test_publish_cli.py`.

## Tests

8 new cases, all boundaries mocked — no network calls:

- **check_regression** (5): no_baseline (no tags), no_baseline (download 404), non-404 download error propagates, pass (within threshold), fail (beyond threshold)
- **promote** (3): tag-hit, branch-hit, unresolved → raises `ValueError`

## Stack

5-PR stack — layers 1–4 split #22, layer 5 adds `--dry-run`:

1. `feat/safetensors-runtime` → `nagish` (PR #28)
2. `feat/publish-utils-and-card` → #28 (PR #29)
3. **This PR** → #29
4. `feat/publish-cli` → this PR (PR #30)
5. `feat/publish-dry-run` → #30 (PR #32)

## Test plan

- [x] `uv run --extra dev --extra publish pytest sign_language_segmentation/tests` — 101 passed
- [x] `uv run --extra dev ruff check sign_language_segmentation/` — clean