### PR TITLE
feat: --dry-run flag on publish CLI

### DIFF
--- a/sign_language_segmentation/publish/publish.py
+++ b/sign_language_segmentation/publish/publish.py
@@ -26,6 +26,7 @@ from sign_language_segmentation.publish.utils import (
     generate_model_card,
     promote,
     get_next_version,
+    get_latest_version,
 )
 
 
@@ -41,6 +42,7 @@ def publish(
     metrics_json: str | None,
     regression_threshold: float,
     no_promote: bool,
+    dry_run: bool = False,
 ) -> None:
     """Main publish workflow."""
     from huggingface_hub import HfApi
@@ -106,6 +108,17 @@ def publish(
         with open(tmp_path / "README.md", "w") as f:
             f.write(model_card)
 
+        if dry_run:
+            preview_path = Path("publish_dry_run.md").resolve()
+            preview_path.write_text(model_card)
+            prev_tag = get_latest_version(repo_id=repo_id)
+            print(
+                f"Dry run — new tag: {tag} (previous: {prev_tag or 'none'}), "
+                f"revision: weekly, regression: {regression_status}"
+            )
+            print(f"Model card written to: {preview_path}")
+            return
+
         # 7. push to weekly branch
         print(f"Pushing to {repo_id} branch 'weekly'...")
         api.create_repo(repo_id=repo_id, exist_ok=True, repo_type="model")
@@ -157,6 +170,9 @@ def main():
     )
     parser.add_argument("--no-promote", action="store_true", help="push without tagging or promoting")
     parser.add_argument("--promote", action="store_true", help="tag the current weekly branch (no upload)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the generated model card and skip all HF writes"
+    )
 
     args = parser.parse_args()
 
@@ -185,6 +201,7 @@ def main():
         metrics_json=args.metrics_json,
         regression_threshold=args.regression_threshold,
         no_promote=args.no_promote,
+        dry_run=args.dry_run,
     )
 
 

--- a/sign_language_segmentation/tests/test_publish_cli.py
+++ b/sign_language_segmentation/tests/test_publish_cli.py
@@ -153,3 +153,35 @@ class TestPublishIntegration:
         mock_api.upload_folder.assert_called_once()
         # regression failed — no promotion
         mock_api.create_tag.assert_not_called()
+
+    def test_dry_run_writes_card_and_skips_hf(self, ckpt_fixture, capsys, tmp_path, monkeypatch):
+        from sign_language_segmentation.publish.publish import publish
+
+        monkeypatch.chdir(tmp_path)
+        mock_api = self._mock_api()
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=True,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=False,
+                dry_run=True,
+            )
+        mock_api.create_repo.assert_not_called()
+        mock_api.create_branch.assert_not_called()
+        mock_api.upload_folder.assert_not_called()
+        mock_api.create_tag.assert_not_called()
+        preview = tmp_path / "publish_dry_run.md"
+        assert preview.exists()
+        out = capsys.readouterr().out
+        assert "new tag: v2026.4.20" in out
+        assert "previous: none" in out
+        assert "revision: weekly" in out
+        assert "regression: skipped" in out


### PR DESCRIPTION
**Depends on:** #30 — [`feat/publish-cli`](https://github.com/sign-language-processing/segmentation/tree/feat/publish-cli)

## Summary

Fifth of a 5-PR stack (layers 1–4 split #22; this layer adds `--dry-run` on top as a separate feature). Adds `--dry-run` to the publish CLI: when set, the pipeline runs through card generation as usual, writes the generated model card to `./publish_dry_run.md` (so it can be previewed in an IDE), prints a one-line summary of `tag / revision / regression` status, and exits before any HF writes.

## Stack

5-PR stack — layers 1–4 split #22, layer 5 adds `--dry-run`:

1. `feat/safetensors-runtime` → `nagish` (PR #28)
2. `feat/publish-utils-and-card` → #28 (PR #29)
3. `feat/publish-hf-ops-and-eval` → #29 (PR #31)
4. `feat/publish-cli` → #31 (PR #30)
5. **This PR** → #30

## Test plan

- [x] `uv run --extra dev --extra publish pytest sign_language_segmentation/tests/test_publish_cli.py` — 5 passed (4 CLI orchestrator + 1 new `test_dry_run_writes_card_and_skips_hf`)
- [x] `uv run --extra dev --extra publish pytest sign_language_segmentation/tests` — 106 passed
- [x] `uv run --extra dev ruff check sign_language_segmentation/publish/` — clean