### PR TITLE
feat: slack notifier for publish results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 CONVEX_URL=
 CONVEX_AUTH_TOKEN=
 WAND_API_KEY=
+
+# slack app bot token (xoxb-...) with chat:write; bot must be invited to SLACK_CHANNEL
+SLACK_BOT_TOKEN=
+# channel id (Cxxxxxx) or name (#channel-name)
+SLACK_CHANNEL=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ platform = [
     "httpx",
     "python-dotenv",
 ]
+slack = [
+    "httpx",
+]
 train = [
     "sign-language-segmentation[dgs]",
     "sign-language-segmentation[platform]",

--- a/sign_language_segmentation/notifier.py
+++ b/sign_language_segmentation/notifier.py
@@ -1,0 +1,117 @@
+"""slack notifier for publish results.
+
+designed as a standalone module: `build_publish_message` returns a slack
+block-kit payload, `post_to_slack` posts a payload via chat.postMessage, and
+`notify` composes both for a one-shot call. integration into the publish
+pipeline is intentionally deferred — consumers wire it in by reading
+`SLACK_BOT_TOKEN` and `SLACK_CHANNEL` from their own environment.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+def build_publish_message(
+    *,
+    repo_id: str,
+    tag: str,
+    revision: str,
+    regression_status: str,
+    metrics: dict[str, dict[str, float]] | None,
+    deployed: bool,
+) -> dict[str, Any]:
+    """build a slack block-kit payload describing a publish result.
+
+    `metrics` is nested: `{"<dataset>.<split>": {"<metric>": value}}`. the
+    top-level `text` field is the plaintext fallback shown in notifications.
+    """
+    status = "deployed" if deployed else "not deployed"
+    header_text = f"{repo_id} — {tag} — {status}"
+
+    summary_fields = [
+        {"type": "mrkdwn", "text": f"*tag*\n`{tag}`"},
+        {"type": "mrkdwn", "text": f"*revision*\n`{revision}`"},
+        {"type": "mrkdwn", "text": f"*regression*\n{regression_status}"},
+        {"type": "mrkdwn", "text": f"*status*\n{status}"},
+    ]
+
+    blocks: list[dict[str, Any]] = [
+        {"type": "header", "text": {"type": "plain_text", "text": header_text}},
+        {"type": "section", "fields": summary_fields},
+    ]
+
+    if metrics:
+        metric_lines = []
+        for key in sorted(metrics):
+            pairs = " · ".join(f"{k}=`{v:.4f}`" for k, v in sorted(metrics[key].items()))
+            metric_lines.append(f"• *{key}*  {pairs}")
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "\n".join(metric_lines)},
+            }
+        )
+
+    repo_url = f"https://huggingface.co/{repo_id}"
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"<{repo_url}|open on huggingface>"}],
+        }
+    )
+
+    return {"text": header_text, "blocks": blocks}
+
+
+def post_to_slack(
+    *,
+    bot_token: str,
+    channel: str,
+    payload: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """post a payload to chat.postMessage. raises on http or slack-level error."""
+    body = {"channel": channel, **payload}
+    resp = httpx.post(
+        SLACK_POST_MESSAGE_URL,
+        headers={
+            "Authorization": f"Bearer {bot_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        json=body,
+        timeout=timeout_seconds,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"slack api error: {data.get('error', 'unknown')}")
+    return data
+
+
+def notify(
+    *,
+    bot_token: str,
+    channel: str,
+    repo_id: str,
+    tag: str,
+    revision: str,
+    regression_status: str,
+    metrics: dict[str, dict[str, float]] | None,
+    deployed: bool,
+) -> dict[str, Any]:
+    """one-shot: build a publish payload and post it to slack."""
+    payload = build_publish_message(
+        repo_id=repo_id,
+        tag=tag,
+        revision=revision,
+        regression_status=regression_status,
+        metrics=metrics,
+        deployed=deployed,
+    )
+    return post_to_slack(bot_token=bot_token, channel=channel, payload=payload)

--- a/sign_language_segmentation/tests/test_notifier.py
+++ b/sign_language_segmentation/tests/test_notifier.py
@@ -1,0 +1,168 @@
+"""tests for the slack notifier module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from sign_language_segmentation.notifier import (
+    build_publish_message,
+    notify,
+    post_to_slack,
+)
+
+
+class TestBuildPublishMessage:
+    def test_deployed_message_contains_key_fields(self):
+        payload = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="pass",
+            metrics={"dgs.test": {"sign_IoU": 0.8521, "hm_IoU": 0.7812}},
+            deployed=True,
+        )
+        rendered = str(payload)
+        assert "sign/segmentation" in rendered
+        assert "v2026.04.20" in rendered
+        assert "abc1234" in rendered
+        assert "pass" in rendered
+        assert "deployed" in rendered
+        assert "0.8521" in rendered
+        assert "0.7812" in rendered
+
+    def test_not_deployed_status(self):
+        payload = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="fail",
+            metrics=None,
+            deployed=False,
+        )
+        assert "not deployed" in str(payload)
+        assert "fail" in str(payload)
+
+    def test_metrics_section_only_when_metrics_provided(self):
+        without = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="skipped",
+            metrics=None,
+            deployed=False,
+        )
+        with_metrics = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="pass",
+            metrics={"dgs.test": {"sign_IoU": 0.85}},
+            deployed=True,
+        )
+        assert len(with_metrics["blocks"]) == len(without["blocks"]) + 1
+
+    def test_fallback_text_for_notifications(self):
+        payload = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="pass",
+            metrics=None,
+            deployed=True,
+        )
+        assert "sign/segmentation" in payload["text"]
+        assert "v2026.04.20" in payload["text"]
+        assert "deployed" in payload["text"]
+
+    def test_metrics_sorted_deterministically(self):
+        payload = build_publish_message(
+            repo_id="sign/segmentation",
+            tag="v2026.04.20",
+            revision="abc1234",
+            regression_status="pass",
+            metrics={
+                "platform.test": {"sign_IoU": 0.7},
+                "dgs.test": {"sign_IoU": 0.8},
+            },
+            deployed=True,
+        )
+        metric_block = next(
+            b for b in payload["blocks"]
+            if b["type"] == "section" and "fields" not in b
+        )
+        text = metric_block["text"]["text"]
+        assert text.index("dgs.test") < text.index("platform.test")
+
+
+class TestPostToSlack:
+    @staticmethod
+    def _ok_response(**extra):
+        resp = MagicMock()
+        resp.json.return_value = {"ok": True, **extra}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_happy_path_uses_bearer_and_channel(self):
+        resp = self._ok_response(ts="1234.5678")
+        with patch("httpx.post", return_value=resp) as mock_post:
+            result = post_to_slack(
+                bot_token="xoxb-test",
+                channel="C12345",
+                payload={"text": "hi", "blocks": []},
+            )
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer xoxb-test"
+        assert kwargs["json"]["channel"] == "C12345"
+        assert kwargs["json"]["text"] == "hi"
+        assert result == {"ok": True, "ts": "1234.5678"}
+
+    def test_slack_api_error_raises(self):
+        resp = MagicMock()
+        resp.json.return_value = {"ok": False, "error": "channel_not_found"}
+        resp.raise_for_status.return_value = None
+        with patch("httpx.post", return_value=resp):
+            with pytest.raises(RuntimeError, match="channel_not_found"):
+                post_to_slack(
+                    bot_token="xoxb-test",
+                    channel="#nope",
+                    payload={"text": "hi"},
+                )
+
+    def test_http_error_propagates(self):
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500 Server Error", request=MagicMock(), response=resp,
+        )
+        with patch("httpx.post", return_value=resp):
+            with pytest.raises(httpx.HTTPStatusError):
+                post_to_slack(
+                    bot_token="xoxb-test",
+                    channel="#general",
+                    payload={"text": "hi"},
+                )
+
+
+class TestNotify:
+    def test_notify_builds_and_posts(self):
+        resp = MagicMock()
+        resp.json.return_value = {"ok": True, "ts": "1.2"}
+        resp.raise_for_status.return_value = None
+        with patch("httpx.post", return_value=resp) as mock_post:
+            notify(
+                bot_token="xoxb-test",
+                channel="C999",
+                repo_id="sign/segmentation",
+                tag="v2026.04.20",
+                revision="abc1234",
+                regression_status="pass",
+                metrics={"dgs.test": {"sign_IoU": 0.85}},
+                deployed=True,
+            )
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["channel"] == "C999"
+        assert "sign/segmentation" in kwargs["json"]["text"]
+        assert "v2026.04.20" in kwargs["json"]["text"]


### PR DESCRIPTION
## Summary

Standalone module `sign_language_segmentation/notifier.py` that reports publish results to Slack. Independent of the publish pipeline — no caller wiring in this PR; can be integrated into `publish.py` later with a one-line call.

## API

| function | role |
|---|---|
| `build_publish_message(*, repo_id, tag, revision, regression_status, metrics, deployed) -> dict` | pure; builds a Slack Block Kit payload (header + summary fields + optional metrics section + HF link) |
| `post_to_slack(*, bot_token, channel, payload, timeout_seconds=10.0) -> dict` | thin I/O via `httpx.post` to `chat.postMessage`; raises on HTTP error or `ok=false`; returns parsed response (so the caller can use `ts` for threading) |
| `notify(*, bot_token, channel, repo_id, tag, revision, regression_status, metrics, deployed) -> dict` | one-shot: `build_publish_message` + `post_to_slack` |

All inputs are explicit kwargs — the module never reads env vars itself. Consumers read `SLACK_BOT_TOKEN` / `SLACK_CHANNEL` and pass them in.

## Setup (for when it's wired in)

1. Create a Slack app at https://api.slack.com/apps, add the `chat:write` scope, install to the workspace
2. Copy the bot token (`xoxb-...`) → `SLACK_BOT_TOKEN`
3. Invite the bot to the target channel (`/invite @<bot-name>`), set `SLACK_CHANNEL` to the channel ID or `#channel-name`

## Changes

- `sign_language_segmentation/notifier.py` — new module
- `sign_language_segmentation/tests/test_notifier.py` — 9 tests, all `httpx.post` mocked, no network
- `pyproject.toml` — new `[slack]` optional group (`httpx`)
- `.env.example` — append `SLACK_BOT_TOKEN` and `SLACK_CHANNEL` with guidance comments

## Test plan

- [x] `uv run --extra dev --extra slack pytest sign_language_segmentation/tests/test_notifier.py` — 9 passed
- [x] `uv run --extra dev ruff check sign_language_segmentation/notifier.py sign_language_segmentation/tests/test_notifier.py` — clean
- [ ] Live smoke: export a real `SLACK_BOT_TOKEN` + `SLACK_CHANNEL` and call `notify(...)` against a sandbox channel to confirm the rendered card
