### PR TITLE
feat: support safetensors fine-tuning

### DIFF
--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -30,7 +30,7 @@ parser.add_argument('--optimizer',
                     choices=['adam', 'adamw', 'adamw-onecycle', 'cosine', 'constant'],
                     default='adamw-onecycle')
 parser.add_argument('--finetune_from', type=str, default=None,
-                    help='checkpoint to fine-tune from')
+                    help='Lightning .ckpt, model.safetensors file, or safetensors model directory to fine-tune from')
 parser.add_argument('--optuna', type=str, default=None, metavar='YAML',
                     help='run Optuna hyperparameter search using ranges from YAML file')
 parser.add_argument('--optuna_trials', type=int, default=50,

--- a/sign_language_segmentation/bin.py
+++ b/sign_language_segmentation/bin.py
@@ -146,6 +146,7 @@ def load_model(
     config_overrides: dict | None = None,
     eval_mode: bool = True,
 ) -> PoseTaggingModel:
+    # skip cache for overrides/train-mode: dicts aren't hashable, and a cached eval-mode model must not leak into fine-tune callers
     if config_overrides or not eval_mode:
         return _load_model_uncached(
             model_dir=model_dir,

--- a/sign_language_segmentation/bin.py
+++ b/sign_language_segmentation/bin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Inference entry point for 2026 sign language segmentation models.
 
-Loads a PyTorch Lightning checkpoint (.ckpt), runs inference on a .pose file,
+Loads a PyTorch Lightning checkpoint or safetensors model, runs inference on a .pose file,
 and writes an ELAN (.eaf) annotation file with SIGN and SENTENCE tiers.
 """
 import argparse
@@ -61,36 +61,99 @@ def _download_from_hf(repo_id: str) -> str:
     )
 
 
-def _load_from_safetensors(model_dir: str, device: str) -> PoseTaggingModel:
-    """Load model from safetensors + config.json directory."""
-    model_dir_path = Path(model_dir)
-    with open(model_dir_path / "config.json") as f:
-        config = json.load(f)
+def _resolve_safetensors_paths(model_path: str) -> tuple[Path, Path]:
+    model_path_obj = Path(model_path)
+    if model_path_obj.suffix == ".safetensors":
+        return model_path_obj, model_path_obj.parent / "config.json"
+    return model_path_obj / "model.safetensors", model_path_obj / "config.json"
+
+
+def _load_model_config(config_path: Path, config_overrides: dict | None = None) -> dict:
+    config = {}
+    if config_path.exists():
+        with open(config_path) as f:
+            config = json.load(f)
+    elif config_overrides is None:
+        raise FileNotFoundError(f"Missing model config: {config_path}")
+
+    if config_overrides:
+        config.update(config_overrides)
+
     # config.json stores tuples as lists — convert pose_dims back
     if "pose_dims" in config:
         config["pose_dims"] = tuple(config["pose_dims"])
-    model = PoseTaggingModel(**config)
-    state_dict = load_safetensors(filename=str(model_dir_path / "model.safetensors"), device=device)
-    model.load_state_dict(state_dict)
-    model = model.to(device)
-    model.eval()
+    return config
+
+
+def _set_model_mode(model: PoseTaggingModel, eval_mode: bool) -> PoseTaggingModel:
+    if eval_mode:
+        model.eval()
+    else:
+        model.train()
     return model
+
+
+def _load_from_safetensors(
+    model_dir: str,
+    device: str,
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
+    """Load model from safetensors + config.json directory or explicit config."""
+    safetensors_path, config_path = _resolve_safetensors_paths(model_path=model_dir)
+    config = _load_model_config(config_path=config_path, config_overrides=config_overrides)
+    model = PoseTaggingModel(**config)
+    state_dict = load_safetensors(filename=str(safetensors_path), device=device)
+    model.load_state_dict(state_dict=state_dict)
+    model = model.to(device)
+    return _set_model_mode(model=model, eval_mode=eval_mode)
 
 
 @lru_cache(maxsize=1)
-def load_model(model_dir: str, device: str = "cpu", revision: str = "") -> PoseTaggingModel:
-    # revision is part of the cache key only — callers pass HF_MODEL_REVISION so a mid-process
-    # env change invalidates the cache entry instead of silently returning a stale model.
+def _load_model_cached(model_dir: str, device: str = "cpu") -> PoseTaggingModel:
+    return _load_model_uncached(model_dir=model_dir, device=device)
+
+
+def _load_model_uncached(
+    model_dir: str,
+    device: str = "cpu",
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
     model_dir_path = Path(model_dir)
     # prefer safetensors if available, fall back to .ckpt
-    if (model_dir_path / "model.safetensors").exists():
-        return _load_from_safetensors(model_dir=str(model_dir), device=device)
+    if model_dir_path.suffix == ".safetensors" or (model_dir_path / "model.safetensors").exists():
+        return _load_from_safetensors(
+            model_dir=str(model_dir),
+            device=device,
+            config_overrides=config_overrides,
+            eval_mode=eval_mode,
+        )
     # backward compat: load .ckpt directly (model_dir might be a file path)
     ckpt_path = model_dir_path if model_dir_path.suffix == ".ckpt" else model_dir_path / "best.ckpt"
-    model = PoseTaggingModel.load_from_checkpoint(checkpoint_path=str(ckpt_path), map_location=device)
+    model = PoseTaggingModel.load_from_checkpoint(
+        checkpoint_path=str(ckpt_path),
+        map_location=device,
+        **(config_overrides or {}),
+    )
     model = model.to(device)
-    model.eval()
-    return model
+    return _set_model_mode(model=model, eval_mode=eval_mode)
+
+
+def load_model(
+    model_dir: str,
+    device: str = "cpu",
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
+    if config_overrides or not eval_mode:
+        return _load_model_uncached(
+            model_dir=model_dir,
+            device=device,
+            config_overrides=config_overrides,
+            eval_mode=eval_mode,
+        )
+    return _load_model_cached(model_dir=model_dir, device=device)
 
 
 @torch.inference_mode()
@@ -122,8 +185,7 @@ def segment_pose(pose: Pose, model_dir: str = None, device: str = "cpu",
         tiers: dict mapping tier name to list of {start, end} segment dicts
     """
     model_dir = model_dir or resolve_model_path()
-    revision = os.environ.get("HF_MODEL_REVISION", "")
-    model = load_model(model_dir=model_dir, device=device, revision=revision)
+    model = load_model(model_dir=model_dir, device=device)
 
     log_probs = run_inference(model=model, pose=pose, device=device)
 

--- a/sign_language_segmentation/tests/test_inference.py
+++ b/sign_language_segmentation/tests/test_inference.py
@@ -1,8 +1,13 @@
 """Smoke tests for inference pipeline."""
+import json
 from pathlib import Path
 
 import pytest
+import torch
 from pose_format import Pose
+from safetensors.torch import save_file as save_safetensors
+
+from sign_language_segmentation.model.model import PoseTaggingModel
 
 EXAMPLE_POSE = Path(__file__).parent / "example.pose"
 
@@ -44,3 +49,50 @@ def test_eaf_has_tiers(example_pose):
     tier_names = list(eaf.tiers.keys())
     assert "SIGN" in tier_names
     assert "SENTENCE" in tier_names
+
+
+@pytest.fixture
+def tiny_model_config() -> dict:
+    return {
+        "pose_dims": (50, 6),
+        "hidden_dim": 8,
+        "encoder_depth": 1,
+        "attn_nhead": 2,
+        "attn_ff_mult": 1,
+    }
+
+
+def test_load_model_reads_safetensors_config_json(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+    config_json = {**tiny_model_config, "pose_dims": list(tiny_model_config["pose_dims"])}
+    (tmp_path / "config.json").write_text(json.dumps(obj=config_json))
+
+    loaded = load_model(model_dir=str(tmp_path), device="cpu")
+
+    assert loaded.training is False
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_accepts_external_safetensors_config(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    model_path = tmp_path / "model.safetensors"
+    save_safetensors(tensors=model.state_dict(), filename=str(model_path))
+
+    loaded = load_model(
+        model_dir=str(model_path),
+        device="cpu",
+        config_overrides=tiny_model_config,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)

--- a/sign_language_segmentation/tests/test_inference.py
+++ b/sign_language_segmentation/tests/test_inference.py
@@ -126,3 +126,32 @@ def test_load_model_ckpt_with_config_overrides(tmp_path: Path, tiny_model_config
     assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
     for name, tensor in model.state_dict().items():
         assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_raises_when_config_missing_and_no_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+
+    with pytest.raises(FileNotFoundError, match="config.json"):
+        load_model(model_dir=str(tmp_path), device="cpu")
+
+
+def test_load_model_safetensors_dir_without_config_uses_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+
+    loaded = load_model(
+        model_dir=str(tmp_path),
+        device="cpu",
+        config_overrides=tiny_model_config,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)

--- a/sign_language_segmentation/tests/test_inference.py
+++ b/sign_language_segmentation/tests/test_inference.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import pytest
+import pytorch_lightning as pl
 import torch
 from pose_format import Pose
 from safetensors.torch import save_file as save_safetensors
@@ -93,6 +94,35 @@ def test_load_model_accepts_external_safetensors_config(tmp_path: Path, tiny_mod
     )
 
     assert loaded.training is True
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_ckpt_with_config_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    ckpt_path = tmp_path / "best.ckpt"
+    torch.save(
+        obj={
+            "state_dict": model.state_dict(),
+            "hyper_parameters": tiny_model_config,
+            "pytorch-lightning_version": pl.__version__,
+        },
+        f=str(ckpt_path),
+    )
+
+    overrides = {**tiny_model_config, "learning_rate": 5e-4}
+    loaded = load_model(
+        model_dir=str(ckpt_path),
+        device="cpu",
+        config_overrides=overrides,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.learning_rate == 5e-4
     assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
     for name, tensor in model.state_dict().items():
         assert torch.equal(input=loaded.state_dict()[name], other=tensor)

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -9,6 +9,7 @@ from pytorch_lightning.loggers import WandbLogger
 from torch.utils.data import ConcatDataset, Dataset
 
 from sign_language_segmentation.args import args
+from sign_language_segmentation.bin import load_model
 from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.model.model import PoseTaggingModel
 
@@ -96,7 +97,12 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     if args.finetune_from:
         print(f"Fine-tuning from: {args.finetune_from}")
-        model = PoseTaggingModel.load_from_checkpoint(args.finetune_from, **model_kwargs)
+        model = load_model(
+            model_dir=args.finetune_from,
+            device="cpu",
+            config_overrides=model_kwargs,
+            eval_mode=False,
+        )
     else:
         model = PoseTaggingModel(**model_kwargs)
 

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -33,6 +33,12 @@ def _collect_split_manifest(dataset: Dataset, dataset_names: str) -> dict:
 _DEFAULT_MONITOR_METRIC = "validation_hm_iou"
 
 
+def _model_load_device(accelerator: str) -> str:
+    if accelerator == "gpu":
+        return "cuda"
+    return accelerator
+
+
 def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_METRIC) -> float:
     """run a single training loop. returns best monitor_metric value.
 
@@ -99,7 +105,7 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
         print(f"Fine-tuning from: {args.finetune_from}")
         model = load_model(
             model_dir=args.finetune_from,
-            device="cpu",
+            device=_model_load_device(accelerator=args.device),
             config_overrides=model_kwargs,
             eval_mode=False,
         )


### PR DESCRIPTION
## Summary
- Extend `load_model` to support safetensors directories/files with optional external config overrides.
- Use `load_model(..., config_overrides=model_kwargs, eval_mode=False)` for `--finetune_from` during training so fine-tuning stays in train mode.
- Add tests covering config.json inference loading and external config override loading.

## Validation
- `uv run ruff check sign_language_segmentation/bin.py sign_language_segmentation/train.py sign_language_segmentation/args.py sign_language_segmentation/tests/test_inference.py`
- `uv run pytest sign_language_segmentation/tests/test_inference.py`
- Rebuilt Docker serve image and verified `/health` plus sample segmentation request.
- Ran one-epoch all-datasets fine-tune from `sign_language_segmentation/dist/2026/model.safetensors` with `--no_wandb` and no Optuna.