### PR TITLE
Fix HPO trial scoring to use best checkpoint metric

### DIFF
--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -124,19 +124,20 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")
 
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=model_dir,
+        filename='best',
+        verbose=True,
+        save_top_k=1,
+        save_last=True,
+        monitor=monitor_metric,
+        every_n_epochs=1,
+        mode='max',
+    )
     callbacks = [
         EarlyStopping(monitor=monitor_metric, patience=args.patience, verbose=True, mode='max'),
         LearningRateMonitor(logging_interval='epoch'),
-        ModelCheckpoint(
-            dirpath=model_dir,
-            filename='best',
-            verbose=True,
-            save_top_k=1,
-            save_last=True,
-            monitor=monitor_metric,
-            every_n_epochs=1,
-            mode='max',
-        ),
+        checkpoint_callback,
     ]
 
     # add Optuna pruning callback when running a sweep
@@ -160,7 +161,7 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=validation_loader)
 
-    best_score = trainer.callback_metrics.get(monitor_metric)
+    best_score = checkpoint_callback.best_model_score
     best_val = float(best_score) if best_score is not None else 0.0
 
     if not overrides:


### PR DESCRIPTION
## Summary
- Return `ModelCheckpoint.best_model_score` from training instead of the last validation metric.
- Fixes automatic training and HP optimization where Optuna trials could be ranked below their own best checkpoint value.

## Validation
- `/home/ziv/git/segmentation/.venv/bin/ruff check sign_language_segmentation/train.py`