### PR TITLE
Add dates to training run names

### DIFF
--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -39,6 +39,12 @@ def _model_load_device(accelerator: str) -> str:
     return accelerator
 
 
+def _dated_run_name(run_name: str | None) -> str:
+    base_name = run_name or "model"
+    today = datetime.now(tz=timezone.utc).strftime("%Y.%m.%d")
+    return f"{base_name}-{today}"
+
+
 def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_METRIC) -> float:
     """run a single training loop. returns best monitor_metric value.
 
@@ -51,6 +57,7 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
     monitor_metric: validation metric to maximize and monitor for early stopping.
     """
     overrides = overrides or {}
+    effective_run_name = _dated_run_name(run_name=args.run_name)
 
     def _get(name: str):
         return overrides[name] if name in overrides else getattr(args, name)
@@ -60,18 +67,18 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
         if overrides and "_trial" in overrides:
             import wandb
             trial_num = overrides["_trial"].number
-            run_name = f"{args.run_name}-t{trial_num}"
+            run_name = f"{effective_run_name}-t{trial_num}"
             wandb.run.name = run_name
             logger = WandbLogger(experiment=wandb.run)
         else:
             logger = WandbLogger(
                 entity=args.wandb_entity,
                 project=args.wandb_project,
-                name=args.run_name,
+                name=effective_run_name,
                 save_dir=args.wandb_dir,
                 log_model=False,
             )
-        effective_args = {**vars(args), **overrides}
+        effective_args = {**vars(args), **overrides, "run_name": effective_run_name}
         logger.log_hyperparams(effective_args)
 
     train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, args=args, batch_size=_get("batch_size"))
@@ -115,7 +122,7 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
     total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     print(f"Parameters: {total_params:,}")
 
-    model_dir = Path("dist") / (args.run_name or "model")
+    model_dir = Path("dist") / effective_run_name
     model_dir.mkdir(parents=True, exist_ok=True)
 
     # write split manifest


### PR DESCRIPTION
## Summary
- Append `YYYY.MM.DD` to the effective training run name and output directory.
- Apply the dated name to W&B runs and Optuna trial run names so experiments are easier to track in Weights & Biases.

## Validation
- `uv run sign_language_segmentation/train.py`