### PR TITLE
Use seeded TPE sampler for HPO

### DIFF
--- a/sign_language_segmentation/hpo.py
+++ b/sign_language_segmentation/hpo.py
@@ -83,7 +83,14 @@ def run_study(
     if wandb_callback:
         objective = wandb_callback.track_in_wandb()(objective)
 
-    study = optuna.create_study(direction="maximize", study_name="segmentation-hpo")
+    # use TPE so early random trials teach Optuna which hyperparameters look promising;
+    # W&B still only records each trial and does not provide sampler state.
+    sampler = optuna.samplers.TPESampler(
+        n_startup_trials=10,
+        multivariate=True,
+        seed=42,
+    )
+    study = optuna.create_study(direction="maximize", study_name="segmentation-hpo", sampler=sampler)
     study.optimize(
         objective,
         n_trials=n_trials,


### PR DESCRIPTION
## Summary
- Configure Optuna HPO to use an explicit TPE sampler.
- Set a fixed sampler seed for reproducible trial suggestions.
- Document why W&B tracking does not replace Optuna sampler state.

## Verification
- uv run --active ruff check sign_language_segmentation/hpo.py