### PR TITLE
Add HF safetensors publishing workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# for interacting with the HF API
+HF_TOKEN=
+HF_MODEL_REPO=
+HF_MODEL_REVISION=
+
+# use a writable HF cache location in restricted environments.
+XDG_CACHE_HOME=

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install ".[dev,server,train]" --extra-index-url https://download.pytorch.org/whl/cpu
+        run: uv pip install ".[dev,server,train,hf]" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Test Code
         run: uv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,8 @@ models/
 logs/
 lightning_logs/
 uv.lock
+*.safetensors
 .cache/
+dist/
+wandb/
+*.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "sign-language-segmentation"
 description = "Sign language pose segmentation model on both the sentence and sign level"
 version = "0.0.1"
 authors = [
     { name = "Amit Moryossef", email = "amitmoryossef@gmail.com" },
-    { name = "Zifan Jiang", email = "jiang@cl.uzh.ch" }
+    { name = "Zifan Jiang", email = "jiang@cl.uzh.ch" },
+    { name = "Ziv Lazarov", email = "ziv.lazarov@nagish.com" }
 ]
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,6 +21,7 @@ dependencies = [
     "pose-anonymization",
     "scikit-learn",
     "pytorch-lightning",
+    "safetensors",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +47,13 @@ server = [
     "Flask-Compress",
     "Flask-Caching",
 ]
+hf = [
+    "huggingface_hub>=0.20.0",
+]
+publish = [
+    "sign-language-segmentation[hf]",
+    "sign-language-segmentation[train]",
+]
 
 [tool.ruff]
 line-length = 120
@@ -56,7 +69,7 @@ where = ["."]
 include = ["sign_language_segmentation*"]
 
 [tool.setuptools.package-data]
-sign_language_segmentation = ["**/*.json", "**/*.ckpt", "**/*.yaml"]
+sign_language_segmentation = ["**/*.json", "**/*.safetensors", "**/*.yaml", "**/*.md"]
 
 [tool.pytest.ini_options]
 addopts = "-v"
@@ -64,4 +77,3 @@ testpaths = ["sign_language_segmentation"]
 
 [project.scripts]
 pose_to_segments = "sign_language_segmentation.bin:main"
-slim_checkpoint = "sign_language_segmentation.slim_checkpoint:main"

--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -30,7 +30,7 @@ parser.add_argument('--optimizer',
                     choices=['adam', 'adamw', 'adamw-onecycle', 'cosine', 'constant'],
                     default='adamw-onecycle')
 parser.add_argument('--finetune_from', type=str, default=None,
-                    help='checkpoint to fine-tune from')
+                    help='Lightning .ckpt, model.safetensors file, or safetensors model directory to fine-tune from')
 parser.add_argument('--optuna', type=str, default=None, metavar='YAML',
                     help='run Optuna hyperparameter search using ranges from YAML file')
 parser.add_argument('--optuna_trials', type=int, default=50,

--- a/sign_language_segmentation/bin.py
+++ b/sign_language_segmentation/bin.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 """Inference entry point for 2026 sign language segmentation models.
 
-Loads a PyTorch Lightning checkpoint (.ckpt), runs inference on a .pose file,
+Loads a PyTorch Lightning checkpoint or safetensors model, runs inference on a .pose file,
 and writes an ELAN (.eaf) annotation file with SIGN and SENTENCE tiers.
 """
 import argparse
+import json
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -13,22 +14,147 @@ import numpy as np
 import pympi
 import torch
 from pose_format import Pose
+from safetensors.torch import load_file as load_safetensors
 
 from sign_language_segmentation.utils.pose import preprocess_pose, compute_velocity
 from sign_language_segmentation.metrics import likeliest_probs_to_segments, filter_segments
 from sign_language_segmentation.model.model import PoseTaggingModel
 
+_BAKED_IN_DIR = Path(__file__).resolve().parent / "dist" / "2026"
 
-def _default_model_path() -> str:
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "dist", "2026", "best.ckpt")
+
+def resolve_model_path() -> str:
+    """Resolve model directory path.
+
+    Priority: MODEL_PATH env > HF_MODEL_REPO env > baked-in package default.
+    """
+    # explicit local path
+    explicit = os.environ.get("MODEL_PATH")
+    if explicit:
+        return explicit
+
+    # huggingface hub download
+    hf_repo = os.environ.get("HF_MODEL_REPO")
+    if hf_repo:
+        return _download_from_hf(hf_repo)
+
+    # baked-in default
+    return str(_BAKED_IN_DIR)
+
+
+def _download_from_hf(repo_id: str) -> str:
+    """Download model from HuggingFace Hub. Returns local cache directory."""
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        raise ImportError(
+            "huggingface_hub is required for HF_MODEL_REPO. "
+            "Install with: pip install sign-language-segmentation[hf]"
+        )
+    revision = os.environ.get("HF_MODEL_REVISION")
+    if not revision:
+        raise ValueError("HF_MODEL_REVISION must be set when using HF_MODEL_REPO")
+    return snapshot_download(
+        repo_id=repo_id,
+        revision=revision,
+        allow_patterns=["model.safetensors", "config.json"],
+    )
+
+
+def _resolve_safetensors_paths(model_path: str) -> tuple[Path, Path]:
+    model_path_obj = Path(model_path)
+    if model_path_obj.suffix == ".safetensors":
+        return model_path_obj, model_path_obj.parent / "config.json"
+    return model_path_obj / "model.safetensors", model_path_obj / "config.json"
+
+
+def _load_model_config(config_path: Path, config_overrides: dict | None = None) -> dict:
+    config = {}
+    if config_path.exists():
+        with open(config_path) as f:
+            config = json.load(f)
+    elif config_overrides is None:
+        raise FileNotFoundError(f"Missing model config: {config_path}")
+
+    if config_overrides:
+        config.update(config_overrides)
+
+    # config.json stores tuples as lists; convert pose_dims back.
+    if "pose_dims" in config:
+        config["pose_dims"] = tuple(config["pose_dims"])
+    return config
+
+
+def _set_model_mode(model: PoseTaggingModel, eval_mode: bool) -> PoseTaggingModel:
+    if eval_mode:
+        model.eval()
+    else:
+        model.train()
+    return model
+
+
+def _load_from_safetensors(
+    model_dir: str,
+    device: str,
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
+    """Load model from safetensors + config.json directory or explicit config."""
+    safetensors_path, config_path = _resolve_safetensors_paths(model_path=model_dir)
+    config = _load_model_config(config_path=config_path, config_overrides=config_overrides)
+    model = PoseTaggingModel(**config)
+    state_dict = load_safetensors(filename=str(safetensors_path), device=device)
+    model.load_state_dict(state_dict=state_dict)
+    model = model.to(device)
+    return _set_model_mode(model=model, eval_mode=eval_mode)
 
 
 @lru_cache(maxsize=1)
-def load_model(model_path: str, device: str = "cpu") -> PoseTaggingModel:
-    model = PoseTaggingModel.load_from_checkpoint(model_path, map_location=device)
+def _load_model_cached(model_dir: str, device: str = "cpu") -> PoseTaggingModel:
+    return _load_model_uncached(model_dir=model_dir, device=device)
+
+
+def _load_model_uncached(
+    model_dir: str,
+    device: str = "cpu",
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
+    model_dir_path = Path(model_dir)
+    # prefer safetensors if available, fall back to .ckpt
+    if model_dir_path.suffix == ".safetensors" or (model_dir_path / "model.safetensors").exists():
+        return _load_from_safetensors(
+            model_dir=str(model_dir),
+            device=device,
+            config_overrides=config_overrides,
+            eval_mode=eval_mode,
+        )
+    # backward compat: load .ckpt directly (model_dir might be a file path)
+    ckpt_path = model_dir_path if model_dir_path.suffix == ".ckpt" else model_dir_path / "best.ckpt"
+    model = PoseTaggingModel.load_from_checkpoint(
+        checkpoint_path=str(ckpt_path),
+        map_location=device,
+        **(config_overrides or {}),
+    )
     model = model.to(device)
-    model.eval()
-    return model
+    return _set_model_mode(model=model, eval_mode=eval_mode)
+
+
+def load_model(
+    model_dir: str,
+    device: str = "cpu",
+    config_overrides: dict | None = None,
+    eval_mode: bool = True,
+) -> PoseTaggingModel:
+    # skip cache for overrides/train-mode: dicts aren't hashable, and a cached eval-mode model must not leak into fine-tune callers
+    if config_overrides or not eval_mode:
+        return _load_model_uncached(
+            model_dir=model_dir,
+            device=device,
+            config_overrides=config_overrides,
+            eval_mode=eval_mode,
+        )
+    return _load_model_cached(model_dir=model_dir, device=device)
 
 
 @torch.inference_mode()
@@ -51,7 +177,7 @@ def run_inference(model: PoseTaggingModel, pose: Pose, device: str) -> dict:
     return model(pose_tensor, timestamps=timestamps)
 
 
-def segment_pose(pose: Pose, model_path: str = None, device: str = "cpu",
+def segment_pose(pose: Pose, model_dir: str = None, device: str = "cpu",
                  min_frames: int = 3, merge_gap: int = 0):
     """Segment a pose into signs and sentences.
 
@@ -59,10 +185,10 @@ def segment_pose(pose: Pose, model_path: str = None, device: str = "cpu",
         eaf: pympi.Elan.Eaf with SIGN and SENTENCE tiers
         tiers: dict mapping tier name to list of {start, end} segment dicts
     """
-    model_path = model_path or _default_model_path()
-    model = load_model(model_path, device)
+    model_dir = model_dir or resolve_model_path()
+    model = load_model(model_dir=model_dir, device=device)
 
-    log_probs = run_inference(model, pose, device)
+    log_probs = run_inference(model=model, pose=pose, device=device)
 
     fps = pose.body.fps
     seg_fn = likeliest_probs_to_segments
@@ -103,7 +229,7 @@ def get_args():
     parser.add_argument("--pose", required=True, type=Path, help="input .pose file")
     parser.add_argument("--elan", required=True, type=str, help="output .eaf file path")
     parser.add_argument("--model", default=None, type=str,
-                        help="path to .ckpt checkpoint (default: dist/2026/best.ckpt)")
+                        help="path to model directory (safetensors) or .ckpt file")
     parser.add_argument("--video", default=None, type=str, help="video file to link in ELAN")
     parser.add_argument("--subtitles", default=None, type=str, help="path to .srt subtitle file")
     parser.add_argument("--no-pose-link", action="store_true", help="do not link pose file in ELAN")
@@ -120,21 +246,21 @@ def get_args():
 def main():
     args = get_args()
 
-    model_path = args.model or _default_model_path()
-    if not os.path.exists(model_path):
+    model_dir = args.model or resolve_model_path()
+    if not os.path.exists(model_dir):
         raise FileNotFoundError(
-            f"Model not found: {model_path}\n"
-            "Download a checkpoint and place it at dist/2026/best.ckpt, "
-            "or pass --model <path>."
+            f"Model not found: {model_dir}\n"
+            "Set HF_MODEL_REPO env var, pass --model <path>, "
+            "or place model files at dist/2026/."
         )
 
     print(f"Loading pose: {args.pose}")
     with open(args.pose, "rb") as f:
         pose = Pose.read(f)
 
-    print(f"Loading model: {model_path}")
+    print(f"Loading model: {model_dir}")
     print("Running inference...")
-    eaf, tiers = segment_pose(pose, model_path=model_path, device=args.device,
+    eaf, tiers = segment_pose(pose, model_dir=model_dir, device=args.device,
                                min_frames=args.min_frames, merge_gap=args.merge_gap)
 
     sign_count = len(tiers["SIGN"])

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -36,7 +36,7 @@ def register_dataset(name: str, cls: type[BaseSegmentationDataset]) -> None:
     DATASET_REGISTRY[name] = cls
 
 
-def _ensure_datasets_registered() -> None:
+def ensure_datasets_registered() -> None:
     """lazily import known dataset packages to trigger registration."""
     if DATASET_REGISTRY:
         return
@@ -52,7 +52,7 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     args are pulled from *args* inside each class's from_args classmethod.
     augment_kwargs (num_frames, velocity, fps_aug, ...) are forwarded as-is.
     """
-    _ensure_datasets_registered()
+    ensure_datasets_registered()
 
     dataset_names = sorted(DATASET_REGISTRY.keys()) if names == "all" else [n.strip() for n in names.split(",")]
     datasets: list[Dataset] = []

--- a/sign_language_segmentation/dist/2026/config.json
+++ b/sign_language_segmentation/dist/2026/config.json
@@ -1,0 +1,20 @@
+{
+  "pose_dims": [
+    50,
+    6
+  ],
+  "hidden_dim": 384,
+  "encoder_depth": 4,
+  "num_classes": 4,
+  "learning_rate": 0.0005,
+  "steps_per_epoch": 69,
+  "max_epochs": 400,
+  "dice_loss_weight": 1.5,
+  "attn_nhead": 8,
+  "attn_ff_mult": 2,
+  "attn_dropout": 0.1,
+  "optimizer": "adamw-onecycle",
+  "fps_aug": true,
+  "frame_dropout": 0.15,
+  "num_frames": 1024
+}

--- a/sign_language_segmentation/publish/__init__.py
+++ b/sign_language_segmentation/publish/__init__.py
@@ -1,0 +1,1 @@
+from sign_language_segmentation.publish.publish import main, publish

--- a/sign_language_segmentation/publish/model_card_template.md
+++ b/sign_language_segmentation/publish/model_card_template.md
@@ -1,0 +1,40 @@
+---
+tags:
+  - sign-language
+  - segmentation
+  - pose
+  - pytorch
+  - pytorch-lightning
+library_name: pytorch
+pipeline_tag: other
+{{model_index}}
+---
+
+# Sign Language Segmentation
+
+CNN-medium-attn model with RoPE for sign language segmentation.
+Jointly trained on sign (gloss) and phrase (sentence) BIO tagging.
+
+**Published:** {{published_at}}
+**Tag:** `{{tag}}`
+**Regression status:** {{regression_status}}
+
+## Architecture
+
+{{architecture_rows}}
+
+{{eval_section}}
+
+## Training Config
+
+{{training_rows}}
+
+{{dataset_section}}
+
+## Usage
+
+```bash
+pip install sign-language-segmentation
+export HF_MODEL_REPO={{repo_id}} HF_MODEL_REVISION={{tag}}
+pose_to_segments --pose input.pose --elan output.eaf
+```

--- a/sign_language_segmentation/publish/publish.py
+++ b/sign_language_segmentation/publish/publish.py
@@ -1,0 +1,209 @@
+"""Publish a model checkpoint to HuggingFace Hub.
+
+Converts a PyTorch Lightning .ckpt to safetensors, optionally evaluates it,
+runs regression checks against the current production model, generates a
+model card, and pushes to the 'weekly' branch on HuggingFace Hub.
+A date-based tag (vYYYY.MM.DD) is only created on promotion
+(regression pass or explicit --promote).
+
+Usage:
+    uv run --extra publish python -m sign_language_segmentation.publish.publish \
+        --checkpoint path/to/best.ckpt --repo org/model-name
+    uv run --extra publish python -m sign_language_segmentation.publish.publish \
+        --repo org/model-name --promote
+"""
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from sign_language_segmentation.publish.utils import (
+    convert_to_safetensors,
+    find_split_manifest,
+    run_evaluation,
+    check_regression,
+    generate_model_card,
+    promote,
+    get_next_version,
+    get_latest_version,
+)
+
+
+def publish(
+    checkpoint: str,
+    repo_id: str,
+    tag: str,
+    datasets: str,
+    corpus: str,
+    poses: str,
+    device: str,
+    skip_eval: bool,
+    metrics_json: str | None,
+    regression_threshold: float,
+    no_promote: bool,
+    dry_run: bool = False,
+) -> None:
+    """Main publish workflow."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # convert to safetensors
+        print(f"Converting {checkpoint} to safetensors...")
+        config = convert_to_safetensors(checkpoint_path=checkpoint, output_dir=tmp_path)
+        print(f"  model.safetensors + config.json written to {tmp_path}")
+
+        # load split manifest for reproducible model cards
+        manifest = find_split_manifest(checkpoint_path=checkpoint)
+
+        # run evaluation unless precomputed metrics are supplied
+        eval_results = None
+        if not skip_eval:
+            if metrics_json:
+                print(f"Loading pre-computed metrics from {metrics_json}")
+                with open(metrics_json) as f:
+                    eval_results = json.load(f)
+            else:
+                print(f"Evaluating on {datasets} dev+test sets...")
+                eval_results = run_evaluation(
+                    checkpoint_path=checkpoint,
+                    datasets=datasets,
+                    corpus=corpus,
+                    poses=poses,
+                    device=device,
+                    split_manifest=manifest,
+                )
+
+        # save eval results
+        if eval_results:
+            with open(tmp_path / "eval_results.json", "w") as f:
+                json.dump(eval_results, f, indent=2)
+
+        # check whether new metrics regress against the previous release
+        regression_status = "skipped"
+        if eval_results and not skip_eval:
+            regression_status, _ = check_regression(
+                new_metrics=eval_results,
+                repo_id=repo_id,
+                threshold=regression_threshold,
+            )
+        # save split manifest
+        if manifest:
+            with open(tmp_path / "split_manifest.json", "w") as f:
+                json.dump(manifest, f, indent=2)
+
+        # generate model card
+        model_card = generate_model_card(
+            config=config,
+            eval_results=eval_results,
+            regression_status=regression_status,
+            tag=tag,
+            repo_id=repo_id,
+            split_manifest=manifest,
+        )
+        with open(tmp_path / "README.md", "w") as f:
+            f.write(model_card)
+
+        if dry_run:
+            preview_path = Path("publish_dry_run.md").resolve()
+            preview_path.write_text(model_card)
+            prev_tag = get_latest_version(repo_id=repo_id)
+            print(
+                f"Dry run — new tag: {tag} (previous: {prev_tag or 'none'}), "
+                f"revision: weekly, regression: {regression_status}"
+            )
+            print(f"Model card written to: {preview_path}")
+            return
+
+        # push to weekly branch
+        print(f"Pushing to {repo_id} branch 'weekly'...")
+        api.create_repo(repo_id=repo_id, exist_ok=True, repo_type="model")
+        api.create_branch(repo_id=repo_id, branch="weekly", exist_ok=True)
+        api.upload_folder(
+            folder_path=str(tmp_path),
+            repo_id=repo_id,
+            revision="weekly",
+            commit_message=f"publish {tag} (regression: {regression_status})",
+        )
+
+        # promote if regression passed; creates a date tag on the weekly branch
+        if regression_status == "fail":
+            print("NOT promoting — regression check failed")
+        elif no_promote:
+            print("Skipping promotion (--no-promote)")
+        else:
+            promote(repo_id=repo_id, tag=tag, revision="weekly")
+
+    print("Done.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Publish a model checkpoint to HuggingFace Hub",
+    )
+    parser.add_argument("--checkpoint", type=str, help="path to .ckpt checkpoint to publish")
+    parser.add_argument("--repo", type=str, required=True, help="HuggingFace repo ID (e.g. org/model-name)")
+    parser.add_argument(
+        "--tag", type=str, default=None, help="version tag (default: vYYYY.MM.DD based on today's date)"
+    )
+
+    # evaluation
+    parser.add_argument("--datasets", type=str, default="dgs", help="comma-separated dataset names for evaluation")
+    parser.add_argument("--corpus", type=str, default="/mnt/nas/GCS/sign-external-datasets/dgs-corpus")
+    parser.add_argument("--poses", type=str, default="/mnt/nas/GCS/sign-mediapipe-holistic-poses")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--skip-eval", action="store_true", help="skip evaluation and regression check")
+    parser.add_argument(
+        "--metrics-json", type=str, help="path to pre-computed metrics JSON (alternative to running eval)"
+    )
+
+    # regression / promotion
+    parser.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=0.005,
+        help="IoU drop tolerance for regression check (default: 0.005)",
+    )
+    parser.add_argument("--no-promote", action="store_true", help="push without tagging or promoting")
+    parser.add_argument("--promote", action="store_true", help="tag the current weekly branch (no upload)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the generated model card and skip all HF writes"
+    )
+
+    args = parser.parse_args()
+
+    # resolve version tag
+    if args.tag is None:
+        args.tag = get_next_version(repo_id=args.repo)
+    print(f"Version: {args.tag}")
+
+    # standalone promote mode
+    if args.promote:
+        promote(repo_id=args.repo, tag=args.tag, revision="weekly")
+        return
+
+    if not args.checkpoint:
+        parser.error("--checkpoint is required (unless using --promote)")
+
+    publish(
+        checkpoint=args.checkpoint,
+        repo_id=args.repo,
+        tag=args.tag,
+        datasets=args.datasets,
+        corpus=args.corpus,
+        poses=args.poses,
+        device=args.device,
+        skip_eval=args.skip_eval,
+        metrics_json=args.metrics_json,
+        regression_threshold=args.regression_threshold,
+        no_promote=args.no_promote,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sign_language_segmentation/publish/utils.py
+++ b/sign_language_segmentation/publish/utils.py
@@ -1,0 +1,395 @@
+"""Utility functions for model publishing: conversion, evaluation, regression, model card."""
+
+import argparse
+import json
+import re
+from datetime import datetime, UTC
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file as save_safetensors
+
+
+# display names for metrics used in both the YAML model-index and the markdown eval table.
+# keys are the raw metric keys emitted by evaluation; values are the human-readable labels.
+_METRIC_DISPLAY_NAMES: dict[str, str] = {
+    "sign_IoU": "Sign IoU",
+    "sentence_IoU": "Sentence IoU",
+    "hm_IoU": "HM IoU",
+    "sign_frame_f1": "Sign Frame F1",
+    "sign_segment_f1": "Sign Segment F1",
+    "sentence_frame_f1": "Sentence Frame F1",
+    "sentence_segment_f1": "Sentence Segment F1",
+}
+
+
+def convert_to_safetensors(checkpoint_path: str, output_dir: Path) -> dict:
+    """Convert .ckpt to safetensors + config.json. Returns hyper_parameters dict."""
+    # Lightning .ckpt files carry hyper_parameters alongside weights; weights_only=True would reject them.
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+
+    sd_bf16 = {k: v.to(torch.bfloat16) if v.is_floating_point() else v for k, v in ckpt["state_dict"].items()}
+    save_safetensors(tensors=sd_bf16, filename=str(output_dir / "model.safetensors"))
+
+    config = ckpt["hyper_parameters"]
+    config = {k: list(v) if isinstance(v, tuple) else v for k, v in config.items()}
+    with open(output_dir / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+
+    return config
+
+
+def find_split_manifest(checkpoint_path: str) -> dict | None:
+    """Look for split_manifest.json in the same directory as the checkpoint."""
+    manifest_path = Path(checkpoint_path).parent / "split_manifest.json"
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            return json.load(f)
+    return None
+
+
+def _parse_version(tag_name: str) -> tuple[int, ...] | None:
+    """Parse a vYYYY.MM.DD[.N] tag. Returns None if not a version tag."""
+    version_re = re.compile(r"^v(\d{4})\.(\d{1,2})\.(\d{1,2})(?:\.(\d+))?$")
+    m = version_re.match(tag_name)
+    if not m:
+        return None
+    parts = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    if m.group(4) is not None:
+        return (*parts, int(m.group(4)))
+    return parts
+
+
+def get_latest_version(repo_id: str) -> str | None:
+    """Get the latest date-based version tag from the HF repo. Returns None if no version tags exist."""
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
+
+    api = HfApi()
+    try:
+        refs = api.list_repo_refs(repo_id=repo_id)
+    except HfHubHTTPError as e:
+        # catch HfHubHTTPError (not bare Exception) so auth/network errors surface;
+        # only 404 (repo not found — first publish) is legitimately "no versions".
+        if e.response.status_code == 404:
+            return None
+        raise
+    versions = []
+    for tag in refs.tags:
+        parsed = _parse_version(tag.name)
+        if parsed:
+            versions.append((parsed, tag.name))
+    if not versions:
+        return None
+    versions.sort()
+    return versions[-1][1]
+
+
+def get_next_version(repo_id: str) -> str:
+    """Determine the next version tag based on today's date (vYYYY.MM.DD).
+
+    If a tag for today already exists, appends a suffix (vYYYY.MM.DD.1, .2, ...).
+    """
+    today = datetime.now(tz=UTC)
+    base = f"v{today.year}.{today.month}.{today.day}"
+
+    latest = get_latest_version(repo_id=repo_id)
+    if latest is None:
+        return base
+
+    parsed = _parse_version(latest)
+    year, month, day = parsed[0], parsed[1], parsed[2]
+    if (year, month, day) != (today.year, today.month, today.day):
+        return base
+
+    # same day — increment suffix
+    suffix = parsed[3] + 1 if len(parsed) == 4 else 1
+    return f"{base}.{suffix}"
+
+
+def _get_test_metrics(eval_results: dict) -> dict:
+    """Extract flat test metrics from eval_results (handles both nested and legacy flat format)."""
+    if "combined" in eval_results:
+        return eval_results["combined"].get("test", {})
+    # single dataset
+    for key, val in eval_results.items():
+        if isinstance(val, dict) and "test" in val:
+            return val["test"]
+    # legacy flat format (no nesting)
+    return eval_results
+
+
+def _build_config_table(config: dict, keys: list[str]) -> str:
+    """Render config keys as a single-row transposed table (keys as columns)."""
+    present = [(k, config[k]) for k in keys if k in config]
+    if not present:
+        return ""
+    header = "| " + " | ".join(k for k, _ in present) + " |"
+    separator = "| " + " | ".join("---" for _ in present) + " |"
+    values = "| " + " | ".join(str(v) for _, v in present) + " |"
+    return f"{header}\n{separator}\n{values}"
+
+
+def _build_model_index(eval_results: dict) -> str:
+    test_metrics = _get_test_metrics(eval_results)
+    lines = [
+        "model-index:",
+        "  - name: sign-language-segmentation",
+        "    results:",
+        "      - task:",
+        "          type: other",
+        "          name: Sign Language Segmentation",
+        "        metrics:",
+    ]
+    for key, value in test_metrics.items():
+        display_name = _METRIC_DISPLAY_NAMES.get(key, key)
+        lines.append(f"          - name: {display_name}")
+        lines.append(f"            type: {key}")
+        lines.append(f"            value: {value:.4f}")
+    return "\n".join(lines)
+
+
+def _build_eval_section(eval_results: dict) -> str:
+    metric_keys = list(_METRIC_DISPLAY_NAMES.keys())
+    headers = ["Dataset", "Split"] + [_METRIC_DISPLAY_NAMES[k] for k in metric_keys]
+    header_row = "| " + " | ".join(headers) + " |"
+    separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+
+    rows = []
+    # separate per-dataset entries from "combined"
+    ds_names = [k for k in eval_results if k != "combined" and isinstance(eval_results[k], dict)]
+    if "combined" in eval_results:
+        ds_names.append("combined")
+
+    for ds_name in ds_names:
+        splits = eval_results[ds_name]
+        if not isinstance(splits, dict) or "test" not in splits:
+            continue
+        is_combined = ds_name == "combined"
+        display_name = ds_name.replace("_", " ").title()
+        if is_combined:
+            display_name = f"**{display_name}**"
+
+        for i, split_name in enumerate(["dev", "test"]):
+            if split_name not in splits:
+                continue
+            metrics = splits[split_name]
+            name_cell = display_name if i == 0 else ""
+            split_cell = split_name
+            if is_combined:
+                split_cell = f"**{split_name}**"
+            values = [f"{metrics.get(key, 0):.4f}" for key in metric_keys]
+            if is_combined:
+                values = [f"**{v}**" for v in values]
+            rows.append("| " + " | ".join([name_cell, split_cell] + values) + " |")
+
+    return f"## Evaluation Results\n\n{header_row}\n{separator}\n" + "\n".join(rows)
+
+
+def _build_dataset_section(split_manifest: dict) -> str:
+    datasets = split_manifest.get("datasets", "unknown")
+    created_at = split_manifest.get("created_at", "unknown")
+    return f"## Dataset\n\n- **Datasets:** {datasets}\n- **Created at:** {created_at}"
+
+
+def generate_model_card(
+    config: dict,
+    eval_results: dict | None,
+    regression_status: str,
+    tag: str,
+    repo_id: str,
+    split_manifest: dict | None,
+) -> str:
+    """Generate a HuggingFace model card from template."""
+    template_path = Path(__file__).resolve().parent / "model_card_template.md"
+    template = template_path.read_text()
+
+    arch_keys = [
+        "hidden_dim",
+        "encoder_depth",
+        "attn_nhead",
+        "attn_ff_mult",
+        "attn_dropout",
+        "num_frames",
+        "pose_dims",
+        "num_classes",
+    ]
+    train_keys = ["learning_rate", "optimizer", "dice_loss_weight", "fps_aug", "frame_dropout"]
+
+    replacements = {
+        "{{published_at}}": datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC"),
+        "{{tag}}": tag,
+        "{{repo_id}}": repo_id,
+        "{{regression_status}}": regression_status,
+        "{{architecture_rows}}": _build_config_table(config=config, keys=arch_keys),
+        "{{training_rows}}": _build_config_table(config=config, keys=train_keys),
+        "{{model_index}}": _build_model_index(eval_results=eval_results) if eval_results else "",
+        "{{eval_section}}": _build_eval_section(eval_results=eval_results) if eval_results else "",
+        "{{dataset_section}}": _build_dataset_section(split_manifest=split_manifest) if split_manifest else "",
+    }
+
+    for placeholder, value in replacements.items():
+        template = template.replace(placeholder, value)
+
+    return template
+
+
+def _eval_single(model, datasets: str, split: str, eval_args, fps_aug: bool, velocity: bool, device: str) -> dict:
+    """Evaluate on a single dataset+split combination."""
+    from sign_language_segmentation.evaluate import evaluate_model
+    from sign_language_segmentation.datasets.common import Split, get_dataloader
+
+    dataloader = get_dataloader(
+        split=Split(split),
+        dataset_names=datasets,
+        args=eval_args,
+        batch_size=1,
+        num_frames=999999,
+        persistent_workers=False,
+        fps_aug=fps_aug,
+        velocity=velocity,
+    )
+    return evaluate_model(model=model, dataloader=dataloader, device=device)
+
+
+def run_evaluation(
+    checkpoint_path: str,
+    datasets: str,
+    corpus: str,
+    poses: str,
+    device: str,
+    split_manifest: dict | None = None,
+) -> dict:
+    """Run model evaluation on each dataset individually and combined, for dev and test.
+
+    Returns nested dict: {dataset_name: {split: {metric: value}}}.
+    Top-level keys include each individual dataset, plus "combined".
+    """
+    from sign_language_segmentation.datasets.common import DATASET_REGISTRY, ensure_datasets_registered
+    from sign_language_segmentation.model.model import PoseTaggingModel
+
+    model = PoseTaggingModel.load_from_checkpoint(checkpoint_path=checkpoint_path, map_location=device)
+    model = model.to(device)
+
+    # fall back to training defaults from args.py when a legacy ckpt does not carry them.
+    fps_aug = getattr(model.hparams, "fps_aug", True)
+    velocity = getattr(model.hparams, "velocity", True)
+
+    eval_args = argparse.Namespace(
+        corpus=corpus,
+        poses=poses,
+        target_fps=None,
+    )
+
+    ensure_datasets_registered()
+    dataset_names = sorted(DATASET_REGISTRY.keys()) if datasets == "all" else [d.strip() for d in datasets.split(",")]
+    splits = ["dev", "test"]
+    results = {}
+
+    # per-dataset evaluation
+    for ds_name in dataset_names:
+        results[ds_name] = {}
+        for s in splits:
+            print(f"  evaluating {ds_name} {s}...")
+            results[ds_name][s] = _eval_single(
+                model=model,
+                datasets=ds_name,
+                split=s,
+                eval_args=eval_args,
+                fps_aug=fps_aug,
+                velocity=velocity,
+                device=device,
+            )
+
+    # combined evaluation (only if multiple datasets)
+    if len(dataset_names) > 1:
+        results["combined"] = {}
+        for s in splits:
+            print(f"  evaluating combined {s}...")
+            results["combined"][s] = _eval_single(
+                model=model,
+                datasets=datasets,
+                split=s,
+                eval_args=eval_args,
+                fps_aug=fps_aug,
+                velocity=velocity,
+                device=device,
+            )
+
+    return results
+
+
+def check_regression(new_metrics: dict, repo_id: str, threshold: float) -> tuple[str, dict | None]:
+    """Compare new metrics against the latest tagged model.
+
+    Returns (status, baseline_metrics) where status is "pass", "fail", or "no_baseline".
+    """
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
+
+    api = HfApi()
+    latest_tag = get_latest_version(repo_id=repo_id)
+    if latest_tag is None:
+        print("No version tags found — skipping regression check")
+        return "no_baseline", None
+    try:
+        print(f"Comparing against latest tag: {latest_tag}")
+        baseline_path = api.hf_hub_download(
+            repo_id=repo_id,
+            filename="eval_results.json",
+            revision=latest_tag,
+        )
+        with open(baseline_path) as f:
+            prod_metrics = json.load(f)
+    except HfHubHTTPError as e:
+        # only a missing baseline file (404) is "no baseline"; auth/network errors must surface.
+        if e.response.status_code == 404:
+            print(f"No eval_results.json at {latest_tag} — skipping regression check")
+            return "no_baseline", None
+        raise
+
+    # extract flat test metrics for comparison
+    new_test = _get_test_metrics(new_metrics)
+    old_test = _get_test_metrics(prod_metrics)
+
+    # check key metrics for regression
+    regressions = []
+    for key in ("sign_IoU", "sentence_IoU", "hm_IoU"):
+        old_val = old_test.get(key, 0.0)
+        new_val = new_test.get(key, 0.0)
+        if new_val < old_val - threshold:
+            regressions.append(f"  {key}: {old_val:.4f} -> {new_val:.4f} (delta: {new_val - old_val:+.4f})")
+
+    if regressions:
+        print("REGRESSION DETECTED:")
+        for r in regressions:
+            print(r)
+        return "fail", prod_metrics
+
+    print("Regression check passed")
+    return "pass", prod_metrics
+
+
+def promote(repo_id: str, tag: str, revision: str) -> None:
+    """Tag a revision to mark it as promoted."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+
+    # resolve the revision to a commit sha
+    refs = api.list_repo_refs(repo_id=repo_id)
+    target_sha = None
+    for ref_tag in refs.tags:
+        if ref_tag.name == revision:
+            target_sha = ref_tag.target_commit
+            break
+    if target_sha is None:
+        for branch in refs.branches:
+            if branch.name == revision:
+                target_sha = branch.target_commit
+                break
+    if target_sha is None:
+        raise ValueError(f"Could not resolve revision {revision!r} to a commit on {repo_id}")
+
+    api.create_tag(repo_id=repo_id, tag=tag, revision=target_sha)
+    print(f"Promoted: tagged '{tag}' at {target_sha[:8]}")

--- a/sign_language_segmentation/tests/test_inference.py
+++ b/sign_language_segmentation/tests/test_inference.py
@@ -1,8 +1,14 @@
 """Smoke tests for inference pipeline."""
+import json
 from pathlib import Path
 
 import pytest
+import pytorch_lightning as pl
+import torch
 from pose_format import Pose
+from safetensors.torch import save_file as save_safetensors
+
+from sign_language_segmentation.model.model import PoseTaggingModel
 
 EXAMPLE_POSE = Path(__file__).parent / "example.pose"
 
@@ -44,3 +50,108 @@ def test_eaf_has_tiers(example_pose):
     tier_names = list(eaf.tiers.keys())
     assert "SIGN" in tier_names
     assert "SENTENCE" in tier_names
+
+
+@pytest.fixture
+def tiny_model_config() -> dict:
+    return {
+        "pose_dims": (50, 6),
+        "hidden_dim": 8,
+        "encoder_depth": 1,
+        "attn_nhead": 2,
+        "attn_ff_mult": 1,
+    }
+
+
+def test_load_model_reads_safetensors_config_json(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+    config_json = {**tiny_model_config, "pose_dims": list(tiny_model_config["pose_dims"])}
+    (tmp_path / "config.json").write_text(json.dumps(obj=config_json))
+
+    loaded = load_model(model_dir=str(tmp_path), device="cpu")
+
+    assert loaded.training is False
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_accepts_external_safetensors_config(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    model_path = tmp_path / "model.safetensors"
+    save_safetensors(tensors=model.state_dict(), filename=str(model_path))
+
+    loaded = load_model(
+        model_dir=str(model_path),
+        device="cpu",
+        config_overrides=tiny_model_config,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_ckpt_with_config_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    ckpt_path = tmp_path / "best.ckpt"
+    torch.save(
+        obj={
+            "state_dict": model.state_dict(),
+            "hyper_parameters": tiny_model_config,
+            "pytorch-lightning_version": pl.__version__,
+        },
+        f=str(ckpt_path),
+    )
+
+    overrides = {**tiny_model_config, "learning_rate": 5e-4}
+    loaded = load_model(
+        model_dir=str(ckpt_path),
+        device="cpu",
+        config_overrides=overrides,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.learning_rate == 5e-4
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)
+
+
+def test_load_model_raises_when_config_missing_and_no_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+
+    with pytest.raises(FileNotFoundError, match="config.json"):
+        load_model(model_dir=str(tmp_path), device="cpu")
+
+
+def test_load_model_safetensors_dir_without_config_uses_overrides(tmp_path: Path, tiny_model_config: dict):
+    from sign_language_segmentation.bin import load_model
+
+    model = PoseTaggingModel(**tiny_model_config)
+    save_safetensors(tensors=model.state_dict(), filename=str(tmp_path / "model.safetensors"))
+
+    loaded = load_model(
+        model_dir=str(tmp_path),
+        device="cpu",
+        config_overrides=tiny_model_config,
+        eval_mode=False,
+    )
+
+    assert loaded.training is True
+    assert loaded.hparams.pose_dims == tiny_model_config["pose_dims"]
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(input=loaded.state_dict()[name], other=tensor)

--- a/sign_language_segmentation/tests/test_publish_cli.py
+++ b/sign_language_segmentation/tests/test_publish_cli.py
@@ -1,0 +1,187 @@
+"""Tests for publish() CLI orchestration with all HF + eval boundaries mocked."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestPublishIntegration:
+    """End-to-end publish() orchestration with every HF + eval boundary mocked."""
+
+    @pytest.fixture
+    def ckpt_fixture(self, tmp_path):
+        import torch
+        ckpt_path = tmp_path / "fake.ckpt"
+        fake_ckpt = {
+            "state_dict": {"layer.weight": torch.randn(2, 2)},
+            "hyper_parameters": {
+                "hidden_dim": 128,
+                "encoder_depth": 4,
+                "attn_nhead": 8,
+                "attn_ff_mult": 4,
+                "attn_dropout": 0.1,
+                "num_frames": 1024,
+                "pose_dims": (75, 3),
+                "num_classes": 3,
+                "learning_rate": 1e-4,
+                "optimizer": "adam",
+                "dice_loss_weight": 0.5,
+                "fps_aug": True,
+                "frame_dropout": 0.1,
+            },
+        }
+        torch.save(fake_ckpt, ckpt_path)
+        return str(ckpt_path)
+
+    def _eval_results(self):
+        return {
+            "ds_a": {
+                "dev": {"sign_IoU": 0.80, "sentence_IoU": 0.70},
+                "test": {"sign_IoU": 0.81, "sentence_IoU": 0.71},
+            },
+            "combined": {
+                "dev": {"sign_IoU": 0.82, "sentence_IoU": 0.72},
+                "test": {"sign_IoU": 0.83, "sentence_IoU": 0.73},
+            },
+        }
+
+    def _mock_api(self):
+        mock_api = MagicMock()
+        # no prior version tags — regression check short-circuits to no_baseline
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="weekly", target_commit="commit123")],
+            branches=[],
+        )
+        return mock_api
+
+    def test_skip_eval_and_no_promote(self, ckpt_fixture):
+        from sign_language_segmentation.publish.publish import publish
+
+        mock_api = self._mock_api()
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=True,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=True,
+            )
+        mock_api.create_repo.assert_called_once()
+        mock_api.create_branch.assert_called_once()
+        mock_api.upload_folder.assert_called_once()
+        # no_promote=True — no tag should be created
+        mock_api.create_tag.assert_not_called()
+
+    def test_skip_eval_with_promote_creates_tag(self, ckpt_fixture):
+        from sign_language_segmentation.publish.publish import publish
+
+        mock_api = self._mock_api()
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=True,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=False,
+            )
+        mock_api.create_tag.assert_called_once()
+        args, kwargs = mock_api.create_tag.call_args
+        assert kwargs["tag"] == "v2026.4.20"
+
+    def test_with_eval_passes_regression_and_promotes(self, ckpt_fixture, tmp_path):
+        from sign_language_segmentation.publish.publish import publish
+
+        mock_api = self._mock_api()
+        # stub run_evaluation and check_regression at the publish.py binding site,
+        # since publish.py imports them at module scope
+        with patch("sign_language_segmentation.publish.publish.run_evaluation",
+                   return_value=self._eval_results()), \
+             patch("sign_language_segmentation.publish.publish.check_regression",
+                   return_value=("pass", None)), \
+             patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=False,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=False,
+            )
+        mock_api.upload_folder.assert_called_once()
+        mock_api.create_tag.assert_called_once()
+
+    def test_regression_fail_does_not_promote(self, ckpt_fixture):
+        from sign_language_segmentation.publish.publish import publish
+
+        mock_api = self._mock_api()
+        with patch("sign_language_segmentation.publish.publish.run_evaluation",
+                   return_value=self._eval_results()), \
+             patch("sign_language_segmentation.publish.publish.check_regression",
+                   return_value=("fail", None)), \
+             patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=False,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=False,
+            )
+        mock_api.upload_folder.assert_called_once()
+        # regression failed — no promotion
+        mock_api.create_tag.assert_not_called()
+
+    def test_dry_run_writes_card_and_skips_hf(self, ckpt_fixture, capsys, tmp_path, monkeypatch):
+        from sign_language_segmentation.publish.publish import publish
+
+        monkeypatch.chdir(tmp_path)
+        mock_api = self._mock_api()
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            publish(
+                checkpoint=ckpt_fixture,
+                repo_id="fake/repo",
+                tag="v2026.4.20",
+                datasets="ds_a",
+                corpus="",
+                poses="",
+                device="cpu",
+                skip_eval=True,
+                metrics_json=None,
+                regression_threshold=0.005,
+                no_promote=False,
+                dry_run=True,
+            )
+        mock_api.create_repo.assert_not_called()
+        mock_api.create_branch.assert_not_called()
+        mock_api.upload_folder.assert_not_called()
+        mock_api.create_tag.assert_not_called()
+        preview = tmp_path / "publish_dry_run.md"
+        assert preview.exists()
+        out = capsys.readouterr().out
+        assert "new tag: v2026.4.20" in out
+        assert "previous: none" in out
+        assert "revision: weekly" in out
+        assert "regression: skipped" in out

--- a/sign_language_segmentation/tests/test_publish_hf_ops.py
+++ b/sign_language_segmentation/tests/test_publish_hf_ops.py
@@ -1,0 +1,128 @@
+"""Tests for HF-facing publish helpers: regression check and promotion."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sign_language_segmentation.publish.utils import check_regression, promote
+
+
+class TestCheckRegression:
+    def test_no_baseline_when_no_tags(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(tags=[], branches=[])
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(new_metrics={}, repo_id="fake/repo", threshold=0.005)
+        assert status == "no_baseline"
+        assert baseline is None
+
+    def _make_hf_http_error(self, status_code: int, msg: str):
+        from huggingface_hub.utils import HfHubHTTPError
+        response = MagicMock()
+        response.status_code = status_code
+        response.headers = {}
+        return HfHubHTTPError(msg, response=response)
+
+    def test_no_baseline_when_download_404s(self):
+        # tag exists but eval_results.json was never uploaded — legitimate "no baseline"
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.side_effect = self._make_hf_http_error(status_code=404, msg="File not found")
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics={"combined": {"test": {"sign_IoU": 0.8}}},
+                repo_id="fake/repo",
+                threshold=0.005,
+            )
+        assert status == "no_baseline"
+        assert baseline is None
+
+    def test_non_404_download_error_propagates(self):
+        # auth/network errors are real failures, not "no baseline"
+        from huggingface_hub.utils import HfHubHTTPError
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.side_effect = self._make_hf_http_error(status_code=401, msg="Unauthorized")
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(HfHubHTTPError):
+                check_regression(
+                    new_metrics={"combined": {"test": {"sign_IoU": 0.8}}},
+                    repo_id="fake/repo",
+                    threshold=0.005,
+                )
+
+    def test_pass_when_within_threshold(self, tmp_path):
+        baseline_file = tmp_path / "eval_results.json"
+        baseline_file.write_text(
+            json.dumps({"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}})
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.return_value = str(baseline_file)
+        new_metrics = {"combined": {"test": {"sign_IoU": 0.798, "sentence_IoU": 0.70}}}
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics=new_metrics, repo_id="fake/repo", threshold=0.005
+            )
+        assert status == "pass"
+        assert baseline == {"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}}
+
+    def test_fail_when_beyond_threshold(self, tmp_path):
+        baseline_file = tmp_path / "eval_results.json"
+        baseline_file.write_text(
+            json.dumps({"combined": {"test": {"sign_IoU": 0.80, "sentence_IoU": 0.70}}})
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.1.1")], branches=[]
+        )
+        mock_api.hf_hub_download.return_value = str(baseline_file)
+        new_metrics = {"combined": {"test": {"sign_IoU": 0.75, "sentence_IoU": 0.70}}}
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            status, baseline = check_regression(
+                new_metrics=new_metrics, repo_id="fake/repo", threshold=0.005
+            )
+        assert status == "fail"
+        assert baseline is not None
+
+
+class TestPromote:
+    def test_tag_found_uses_tag_commit(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[SimpleNamespace(name="weekly", target_commit="abc12345deadbeef")],
+            branches=[],
+        )
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            promote(repo_id="fake/repo", tag="v2026.4.20", revision="weekly")
+        mock_api.create_tag.assert_called_once_with(
+            repo_id="fake/repo", tag="v2026.4.20", revision="abc12345deadbeef"
+        )
+
+    def test_branch_found_uses_branch_commit(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(
+            tags=[],
+            branches=[SimpleNamespace(name="weekly", target_commit="feedface00000000")],
+        )
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            promote(repo_id="fake/repo", tag="v2026.4.20", revision="weekly")
+        mock_api.create_tag.assert_called_once_with(
+            repo_id="fake/repo", tag="v2026.4.20", revision="feedface00000000"
+        )
+
+    def test_raises_when_unresolved(self):
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = SimpleNamespace(tags=[], branches=[])
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(ValueError, match="Could not resolve revision"):
+                promote(repo_id="fake/repo", tag="v2026.4.20", revision="nonexistent")
+        mock_api.create_tag.assert_not_called()

--- a/sign_language_segmentation/tests/test_publish_utils.py
+++ b/sign_language_segmentation/tests/test_publish_utils.py
@@ -1,0 +1,307 @@
+"""Unit tests for publish/utils.py pure helpers."""
+
+from datetime import datetime, UTC
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from sign_language_segmentation.publish.utils import (
+    _build_config_table,
+    _build_dataset_section,
+    _build_eval_section,
+    _build_model_index,
+    _get_test_metrics,
+    _parse_version,
+    find_split_manifest,
+    generate_model_card,
+    get_latest_version,
+    get_next_version,
+)
+
+
+class TestParseVersion:
+    def test_ymd_returns_3_tuple(self):
+        assert _parse_version("v2026.4.20") == (2026, 4, 20)
+
+    def test_ymd_with_suffix_returns_4_tuple(self):
+        assert _parse_version("v2026.4.20.3") == (2026, 4, 20, 3)
+
+    def test_zero_padded_month_day(self):
+        assert _parse_version("v2026.04.20") == (2026, 4, 20)
+
+    def test_garbage_returns_none(self):
+        assert _parse_version("nope") is None
+        assert _parse_version("v") is None
+        assert _parse_version("v1.2") is None
+        assert _parse_version("") is None
+
+    def test_legacy_semver_returns_none(self):
+        # YYYY.MM.DD regex requires a 4-digit year, so semver-style v1.0.0 won't match
+        assert _parse_version("v1.0.0") is None
+        assert _parse_version("v1.0.abc") is None
+
+
+class TestGetLatestVersion:
+    def test_mixed_tags_picks_max(self):
+        with patch("sign_language_segmentation.publish.utils.HfApi", create=True) as _:
+            pass
+        mock_refs = SimpleNamespace(
+            tags=[
+                SimpleNamespace(name="v2026.1.1"),
+                SimpleNamespace(name="v2026.4.20"),
+                SimpleNamespace(name="weekly"),
+                SimpleNamespace(name="v2026.3.15.2"),
+                SimpleNamespace(name="release-v1"),
+            ]
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_no_version_tags_returns_none(self):
+        mock_refs = SimpleNamespace(tags=[SimpleNamespace(name="weekly"), SimpleNamespace(name="main")])
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") is None
+
+    def _make_hf_http_error(self, status_code: int, msg: str):
+        # HfHubHTTPError's __init__ touches response.headers; build a rich enough mock
+        from huggingface_hub.utils import HfHubHTTPError
+        response = MagicMock()
+        response.status_code = status_code
+        response.headers = {}
+        return HfHubHTTPError(msg, response=response)
+
+    def test_404_returns_none(self):
+        # first-publish: repo doesn't exist yet on HF
+        err = self._make_hf_http_error(status_code=404, msg="Repo not found")
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.side_effect = err
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") is None
+
+    def test_non_404_propagates(self):
+        # auth/network errors must surface — they're not "no versions", they're real failures
+        from huggingface_hub.utils import HfHubHTTPError
+        err = self._make_hf_http_error(status_code=401, msg="Unauthorized")
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.side_effect = err
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            with pytest.raises(HfHubHTTPError):
+                get_latest_version(repo_id="fake/repo")
+
+    def test_suffix_beats_base_same_day(self):
+        mock_refs = SimpleNamespace(
+            tags=[SimpleNamespace(name="v2026.4.20"), SimpleNamespace(name="v2026.4.20.1")]
+        )
+        mock_api = MagicMock()
+        mock_api.list_repo_refs.return_value = mock_refs
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            assert get_latest_version(repo_id="fake/repo") == "v2026.4.20.1"
+
+
+class TestGetNextVersion:
+    def _freeze_today(self, monkeypatch, y, m, d):
+        class FrozenDT:
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(y, m, d, tzinfo=tz or UTC)
+        monkeypatch.setattr("sign_language_segmentation.publish.utils.datetime", FrozenDT)
+
+    def test_no_baseline_returns_base(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: None
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_prior_date_returns_base(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.1.1"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20"
+
+    def test_same_day_base_increments_to_1(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.4.20"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20.1"
+
+    def test_same_day_with_suffix_increments(self, monkeypatch):
+        self._freeze_today(monkeypatch, 2026, 4, 20)
+        monkeypatch.setattr(
+            "sign_language_segmentation.publish.utils.get_latest_version", lambda repo_id: "v2026.4.20.1"
+        )
+        assert get_next_version(repo_id="fake/repo") == "v2026.4.20.2"
+
+
+class TestFindSplitManifest:
+    def test_returns_none_when_missing(self, tmp_path):
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.touch()
+        assert find_split_manifest(checkpoint_path=str(ckpt)) is None
+
+    def test_loads_manifest_from_sibling(self, tmp_path):
+        (tmp_path / "split_manifest.json").write_text('{"datasets": "dgs", "created_at": "2026-01-01"}')
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.touch()
+        manifest = find_split_manifest(checkpoint_path=str(ckpt))
+        assert manifest == {"datasets": "dgs", "created_at": "2026-01-01"}
+
+
+class TestGetTestMetrics:
+    def test_combined_wins(self):
+        results = {
+            "ds_a": {"test": {"sign_IoU": 0.5}},
+            "combined": {"test": {"sign_IoU": 0.9}},
+        }
+        assert _get_test_metrics(results) == {"sign_IoU": 0.9}
+
+    def test_single_dataset_picks_first(self):
+        results = {"ds_a": {"test": {"sign_IoU": 0.5}}}
+        assert _get_test_metrics(results) == {"sign_IoU": 0.5}
+
+    def test_legacy_flat_returns_as_is(self):
+        results = {"sign_IoU": 0.5, "sentence_IoU": 0.6}
+        assert _get_test_metrics(results) == results
+
+
+class TestBuildConfigTable:
+    def test_empty_keys_returns_empty(self):
+        assert _build_config_table(config={"a": 1}, keys=[]) == ""
+
+    def test_no_matching_keys_returns_empty(self):
+        assert _build_config_table(config={"a": 1}, keys=["b", "c"]) == ""
+
+    def test_partial_match_renders_present_only(self):
+        out = _build_config_table(config={"a": 1, "c": 3}, keys=["a", "b", "c"])
+        assert "| a | c |" in out
+        assert "| 1 | 3 |" in out
+        assert "b" not in out
+
+    def test_tuple_value_stringified(self):
+        out = _build_config_table(config={"pose_dims": (75, 3)}, keys=["pose_dims"])
+        assert "(75, 3)" in out
+
+
+class TestBuildModelIndex:
+    def test_emits_yaml_fragment(self):
+        results = {"combined": {"test": {"sign_IoU": 0.8765, "sentence_IoU": 0.5}}}
+        out = _build_model_index(eval_results=results)
+        assert "model-index:" in out
+        assert "- name: Sign IoU" in out
+        assert "type: sign_IoU" in out
+        assert "value: 0.8765" in out
+        assert "value: 0.5000" in out
+
+    def test_formats_to_four_decimals(self):
+        results = {"combined": {"test": {"sign_IoU": 1.0 / 3.0}}}
+        out = _build_model_index(eval_results=results)
+        assert "value: 0.3333" in out
+
+
+class TestBuildEvalSection:
+    def test_per_dataset_and_combined(self):
+        results = {
+            "ds_a": {
+                "dev": {"sign_IoU": 0.5, "sentence_IoU": 0.4},
+                "test": {"sign_IoU": 0.55, "sentence_IoU": 0.45},
+            },
+            "combined": {
+                "dev": {"sign_IoU": 0.6, "sentence_IoU": 0.5},
+                "test": {"sign_IoU": 0.65, "sentence_IoU": 0.55},
+            },
+        }
+        out = _build_eval_section(eval_results=results)
+        assert "## Evaluation Results" in out
+        assert "Ds A" in out
+        assert "**Combined**" in out
+        assert "**test**" in out  # combined splits are bolded
+
+    def test_missing_metrics_default_to_zero(self):
+        results = {"ds_a": {"test": {"sign_IoU": 0.5}}}
+        out = _build_eval_section(eval_results=results)
+        assert "0.0000" in out  # for metrics absent from dict
+
+
+class TestBuildDatasetSection:
+    def test_renders_fields(self):
+        manifest = {"datasets": "dgs,platform", "created_at": "2026-04-20"}
+        out = _build_dataset_section(split_manifest=manifest)
+        assert "dgs,platform" in out
+        assert "2026-04-20" in out
+
+    def test_missing_fields_default_to_unknown(self):
+        out = _build_dataset_section(split_manifest={})
+        assert "unknown" in out
+
+
+class TestGenerateModelCard:
+    def _fixture_config(self):
+        return {
+            "hidden_dim": 128,
+            "encoder_depth": 4,
+            "attn_nhead": 8,
+            "attn_ff_mult": 4,
+            "attn_dropout": 0.1,
+            "num_frames": 1024,
+            "pose_dims": (75, 3),
+            "num_classes": 3,
+            "learning_rate": 1e-4,
+            "optimizer": "adam",
+            "dice_loss_weight": 0.5,
+            "fps_aug": True,
+            "frame_dropout": 0.1,
+        }
+
+    def _fixture_eval(self):
+        return {
+            "ds_a": {"dev": {"sign_IoU": 0.5}, "test": {"sign_IoU": 0.55}},
+            "combined": {"dev": {"sign_IoU": 0.6}, "test": {"sign_IoU": 0.65}},
+        }
+
+    def test_replaces_every_placeholder(self):
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=self._fixture_eval(),
+            regression_status="pass",
+            tag="v2026.4.20",
+            repo_id="test/repo",
+            split_manifest={"datasets": "ds_a", "created_at": "2026-04-20"},
+        )
+        assert "{{" not in out
+        assert "}}" not in out
+        assert "v2026.4.20" in out
+        assert "pass" in out
+        assert "test/repo" in out
+
+    def test_omits_optional_sections_when_missing(self):
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=None,
+            regression_status="no_baseline",
+            tag="v2026.4.20",
+            repo_id="test/repo",
+            split_manifest=None,
+        )
+        assert "{{" not in out
+        assert "## Evaluation Results" not in out
+
+    def test_no_language_field_in_frontmatter(self):
+        # language: was dropped per review comment #2
+        out = generate_model_card(
+            config=self._fixture_config(),
+            eval_results=None,
+            regression_status="pass",
+            tag="v2026.4.20",
+            repo_id="test/repo",
+            split_manifest=None,
+        )
+        # frontmatter is the first `---...---` block
+        frontmatter = out.split("---", 2)[1]
+        assert "language:" not in frontmatter

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -9,6 +9,7 @@ from pytorch_lightning.loggers import WandbLogger
 from torch.utils.data import ConcatDataset, Dataset
 
 from sign_language_segmentation.args import args
+from sign_language_segmentation.bin import load_model
 from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.model.model import PoseTaggingModel
 
@@ -36,6 +37,12 @@ def _dated_run_name(run_name: str | None) -> str:
     base_name = run_name or "model"
     today = datetime.now(tz=timezone.utc).strftime("%Y.%m.%d")
     return f"{base_name}-{today}"
+
+
+def _model_load_device(accelerator: str) -> str:
+    if accelerator == "gpu":
+        return "cuda"
+    return accelerator
 
 
 def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_METRIC) -> float:
@@ -103,7 +110,12 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     if args.finetune_from:
         print(f"Fine-tuning from: {args.finetune_from}")
-        model = PoseTaggingModel.load_from_checkpoint(args.finetune_from, **model_kwargs)
+        model = load_model(
+            model_dir=args.finetune_from,
+            device=_model_load_device(accelerator=args.device),
+            config_overrides=model_kwargs,
+            eval_mode=False,
+        )
     else:
         model = PoseTaggingModel(**model_kwargs)
 


### PR DESCRIPTION
## Stack
Stacked PR 5 of 5. Depends on #46.

## Summary
- Add safetensors runtime loading, fine-tuning support, and a packaged safetensors model artifact.
- Add Hugging Face model resolution and publish utilities for conversion, evaluation, regression checks, model cards, upload, promotion, and dry runs.
- Add publish/inference tests and package metadata updates, including Ziv Lazarov as a package author.

## Tests
- `uv run pytest` on `public-stack/hf-publish`: 92 passed