### PR TITLE
Refactor dataset loading foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ models/
 logs/
 lightning_logs/
 uv.lock
+.cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pose-format>=0.8.1",
-    "numpy<2",
+    "numpy",
     "pympi-ling",
     "torch",
     "pose-anonymization",
@@ -20,12 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dgs = [
-    "sign_language_datasets",
-    "tensorflow<2.19",
-    "tensorflow-datasets==4.9.2",
-    "pyarrow",  # transitive: tensorflow-datasets needs it at import time
     "lxml",
-    "webvtt-py",  # transitive: sign_language_datasets eagerly imports mediapi_skel
 ]
 train = [
     "sign-language-segmentation[dgs]",

--- a/sign_language_segmentation/args.py
+++ b/sign_language_segmentation/args.py
@@ -37,8 +37,8 @@ parser.add_argument('--optuna_trials', type=int, default=50,
                     help='number of Optuna trials (default: 50)')
 
 # Data
-parser.add_argument('--datasets', type=str, default='dgs',
-                    help='comma-separated dataset names to train on (e.g. dgs,platform)')
+parser.add_argument('--datasets', type=str, default='all',
+                    help='comma-separated dataset names to train on (e.g. dgs), or "all" for every registered dataset')
 parser.add_argument('--corpus', default='/mnt/nas/GCS/sign-external-datasets/dgs-corpus')
 parser.add_argument('--poses', default='/mnt/nas/GCS/sign-mediapipe-holistic-poses')
 parser.add_argument('--velocity', action='store_true', default=True,

--- a/sign_language_segmentation/datasets/__init__.py
+++ b/sign_language_segmentation/datasets/__init__.py
@@ -2,16 +2,22 @@ from sign_language_segmentation.datasets.common import (
     DATASET_REGISTRY,
     BaseSegmentationDataset,
     Split,
+    assign_split,
     build_datasets,
     collate_fn,
+    get_dataloader,
     register_dataset,
+    split_bucket,
 )
 
 __all__ = [
     "BaseSegmentationDataset",
     "DATASET_REGISTRY",
     "Split",
+    "assign_split",
     "build_datasets",
     "collate_fn",
+    "get_dataloader",
     "register_dataset",
+    "split_bucket",
 ]

--- a/sign_language_segmentation/datasets/common.py
+++ b/sign_language_segmentation/datasets/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from argparse import Namespace
 import hashlib
+from pathlib import Path
 import random
 from enum import StrEnum
 
@@ -10,10 +11,13 @@ import numpy as np
 import torch
 from pose_format import Pose
 from torch import Tensor
-from torch.utils.data import ConcatDataset, Dataset
+from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
 from sign_language_segmentation.utils.bio import BIO, create_bio, create_bio_from_times
 from sign_language_segmentation.utils.pose import compute_velocity, preprocess_pose
+
+# project-level cache directory for generated dataset metadata.
+CACHE_DIR = Path(__file__).resolve().parents[2] / ".cache"
 
 
 class Split(StrEnum):
@@ -49,7 +53,7 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     """
     _ensure_datasets_registered()
 
-    dataset_names = [n.strip() for n in names.split(",")]
+    dataset_names = sorted(DATASET_REGISTRY.keys()) if names == "all" else [n.strip() for n in names.split(",")]
     datasets: list[Dataset] = []
     for name in dataset_names:
         if name not in DATASET_REGISTRY:
@@ -63,6 +67,41 @@ def build_datasets(names: str, split: Split, args: Namespace, **augment_kwargs) 
     return ConcatDataset(datasets)
 
 
+def get_dataloader(
+    split: Split,
+    dataset_names: str,
+    args: Namespace,
+    batch_size: int | None = None,
+    num_frames: int | None = None,
+    persistent_workers: bool = True,
+    **augment_overrides,
+) -> DataLoader:
+    """build a DataLoader for one or more datasets.
+
+    augment kwargs default to values from *args* but can be overridden
+    via **augment_overrides (e.g. fps_aug=False for evaluation).
+    """
+    augment_kwargs = dict(
+        num_frames=num_frames if num_frames is not None else getattr(args, "num_frames", 999999),
+        velocity=getattr(args, "velocity", True),
+        fps_aug=getattr(args, "fps_aug", True),
+        frame_dropout=getattr(args, "frame_dropout", 0.0),
+        body_part_dropout=getattr(args, "body_part_dropout", 0.0) if split == Split.TRAIN else 0.0,
+    )
+    augment_kwargs.update(augment_overrides)
+    dataset = build_datasets(names=dataset_names, split=split, args=args, **augment_kwargs)
+    return DataLoader(
+        dataset,
+        batch_size=batch_size or getattr(args, "batch_size", 1),
+        shuffle=(split == Split.TRAIN),
+        collate_fn=collate_fn,
+        num_workers=8,
+        persistent_workers=persistent_workers,
+        prefetch_factor=4 if persistent_workers else 2,
+        pin_memory=True,
+    )
+
+
 def md5sum(file_path: str) -> str:
     """compute MD5 hash of a file."""
     h = hashlib.md5()
@@ -72,13 +111,43 @@ def md5sum(file_path: str) -> str:
     return h.hexdigest()
 
 
+def split_bucket(video_id: str, seed: int) -> int:
+    """deterministic hash-based split assignment. returns 0-999."""
+    h = hashlib.sha256(f"{video_id}_{seed}".encode()).hexdigest()
+    return int(h, 16) % 1000
+
+
+def assign_split(
+    video_id: str,
+    split_seed: int,
+    dev_ratio: float = 0.1,
+    test_ratio: float = 0.1,
+) -> Split:
+    """assign a split to a video ID based on deterministic hashing."""
+    train_threshold = int((1.0 - dev_ratio - test_ratio) * 1000)
+    dev_threshold = int((1.0 - test_ratio) * 1000)
+    bucket = split_bucket(video_id=video_id, seed=split_seed)
+    if bucket < train_threshold:
+        return Split.TRAIN
+    if bucket < dev_threshold:
+        return Split.DEV
+    return Split.TEST
+
+
 class BaseSegmentationDataset(Dataset, ABC):
     """base class for segmentation datasets.
 
     Subclasses must populate self.items in __init__ — a list of dicts with keys:
     id, pose_path, fps, total_frames, glosses (sign spans), sentences (phrase spans).
     All span times must be in milliseconds.
+
+    Split tracking via _init_split_tracking / _track_and_filter / get_split_manifest.
+    Default get_split_manifest uses split_seed (for hash-based splits); subclasses
+    with fixed splits (e.g. DGS) can override get_split_manifest.
     """
+
+    # dataset name used in manifests — subclasses should set this
+    dataset_name: str = "base"
 
     items: list[dict]
     split: Split
@@ -87,9 +156,24 @@ class BaseSegmentationDataset(Dataset, ABC):
     fps_aug: bool
     frame_dropout: float
     body_part_dropout: float
+    _all_split_ids: dict[str, list[str]]
 
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None: ...
+
+    def _init_split_tracking(self) -> None:
+        """initialize split tracking — call at the start of subclass __init__."""
+        self._all_split_ids = {
+            Split.TRAIN: [],
+            Split.DEV: [],
+            Split.TEST: [],
+        }
+
+    def _track_and_filter(self, video_id: str, video_split: Split, item: dict) -> None:
+        """track a video's split assignment and append to self.items if it matches."""
+        self._all_split_ids[video_split].append(video_id)
+        if video_split == self.split:
+            self.items.append(item)
 
     @classmethod
     @abstractmethod
@@ -97,8 +181,15 @@ class BaseSegmentationDataset(Dataset, ABC):
         """construct from a parsed argument namespace + shared augment kwargs."""
         ...
 
-    @abstractmethod
-    def get_split_manifest(self) -> dict: ...
+    def get_split_manifest(self) -> dict:
+        """return manifest of video IDs per split for reproducibility tracking."""
+        return {
+            "dataset": self.dataset_name,
+            "split_seed": self.split_seed,
+            "splits": {
+                s.value: sorted(ids) for s, ids in self._all_split_ids.items()
+            },
+        }
 
     def __len__(self) -> int:
         return len(self.items)

--- a/sign_language_segmentation/datasets/dgs/dataset.py
+++ b/sign_language_segmentation/datasets/dgs/dataset.py
@@ -2,33 +2,24 @@ from __future__ import annotations
 
 from argparse import Namespace
 import json
-import os
+from pathlib import Path
 
 from pose_format import Pose
 from pose_format.pose_body import EmptyPoseBody
 
-# shim: sign_language_datasets imports get_dl_dirname which was renamed in tfds >=4.9
-import tensorflow_datasets.core.download.resource as _tfds_resource
-if not hasattr(_tfds_resource, "get_dl_dirname"):
-    _tfds_resource.get_dl_dirname = _tfds_resource.get_dl_fname
-
-from sign_language_datasets.datasets.dgs_corpus.dgs_utils import get_elan_sentences
-
-from sign_language_segmentation.datasets.common import BaseSegmentationDataset, Split, md5sum
+from sign_language_segmentation.datasets.dgs.utils import (
+    get_elan_sentences,
+    is_joke,
+)
+from sign_language_segmentation.datasets.common import CACHE_DIR, BaseSegmentationDataset, Split, md5sum
 
 EXCLUDED_IDS: set[str] = {"1289910", "1245887", "1289868", "1246064", "1584617"}
 
 
-def is_joke(corpus_dir: str, doc_id: str) -> bool:
-    cmdi_path = os.path.join(corpus_dir, "videos", doc_id, "data.cmdi")
-    if not os.path.exists(cmdi_path):
-        return False
-    with open(cmdi_path, "r") as f:
-        return "<cmdp:Task>Joke</cmdp:Task>" in f.read()
-
-
 class DGSSegmentationDataset(BaseSegmentationDataset):
     """reads DGS corpus poses on the fly with efficient partial reading."""
+
+    dataset_name = "dgs"
 
     def __init__(
         self,
@@ -44,8 +35,8 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
         splits_path: str | None = None,
         cache_path: str | None = None,
     ):
-        self.corpus_dir = corpus_dir
-        self.poses_dir = poses_dir
+        self.corpus_dir = Path(corpus_dir)
+        self.poses_dir = Path(poses_dir)
         self.split = split
         self.num_frames = num_frames
         self.velocity = velocity
@@ -55,48 +46,52 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
         self.body_part_dropout = body_part_dropout
 
         if splits_path is None:
-            splits_path = os.path.join(os.path.dirname(__file__), "splits.json")
-        with open(splits_path) as f:
-            splits = json.load(f)
-
+            splits_path = str(Path(__file__).parent / "splits.json")
+        self.splits_path = splits_path
+        splits = json.loads(Path(splits_path).read_text())
         dev_ids = set(splits["dev"])
         test_ids = set(splits["test"])
 
-        if cache_path is None:
-            cache_path = os.path.join(corpus_dir, ".segmentation_cache.json")
+        self._init_split_tracking()
+        self.items = []
 
-        self.items: list[dict] = []
-        cache = self._load_cache(cache_path)
+        if cache_path is None:
+            dgs_cache_dir = CACHE_DIR / "dgs"
+            dgs_cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_path = str(dgs_cache_dir / "segmentation_cache.json")
+
+        cache_file = Path(cache_path) if cache_path else self.corpus_dir / ".segmentation_cache.json"
+        cache = self._load_cache(cache_file)
         cache_dirty = False
 
-        videos_dir = os.path.join(corpus_dir, "videos")
+        videos_dir = self.corpus_dir / "videos"
         doc_ids = sorted(
-            d for d in os.listdir(videos_dir)
-            if os.path.isdir(os.path.join(videos_dir, d))
+            d.name for d in videos_dir.iterdir() if d.is_dir()
         )
 
         for doc_id in doc_ids:
-            if doc_id in EXCLUDED_IDS or is_joke(corpus_dir, doc_id):
+            if doc_id in EXCLUDED_IDS or is_joke(self.corpus_dir, doc_id):
                 continue
 
-            if split == Split.DEV and doc_id not in dev_ids:
-                continue
-            if split == Split.TEST and doc_id not in test_ids:
-                continue
-            if split == Split.TRAIN and (doc_id in dev_ids or doc_id in test_ids):
+            # fixed split from splits.json (research-standard split)
+            if doc_id in dev_ids:
+                doc_split = Split.DEV
+            elif doc_id in test_ids:
+                doc_split = Split.TEST
+            else:
+                doc_split = Split.TRAIN
+
+            eaf_path = videos_dir / doc_id / "data.eaf"
+            if not eaf_path.exists() or eaf_path.stat().st_size < 10000:
                 continue
 
-            eaf_path = os.path.join(videos_dir, doc_id, "data.eaf")
-            if not os.path.exists(eaf_path) or os.path.getsize(eaf_path) < 10000:
-                continue
-
-            sentences = list(get_elan_sentences(eaf_path))
+            sentences = list(get_elan_sentences(str(eaf_path)))
             if not sentences:
                 continue
 
             for person in ("a", "b"):
-                video_path = os.path.join(videos_dir, doc_id, f"video_{person}.mp4")
-                if not os.path.exists(video_path):
+                video_path = videos_dir / doc_id / f"video_{person}.mp4"
+                if not video_path.exists():
                     continue
 
                 cache_key = f"{doc_id}_{person}"
@@ -106,9 +101,9 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                     fps = cache[cache_key]["fps"]
                     total_frames = cache[cache_key]["total_frames"]
                 else:
-                    video_hash = md5sum(video_path)
-                    pose_path = os.path.join(poses_dir, f"{video_hash}.pose")
-                    if not os.path.exists(pose_path):
+                    video_hash = md5sum(str(video_path))
+                    pose_path = self.poses_dir / f"{video_hash}.pose"
+                    if not pose_path.exists():
                         continue
                     with open(pose_path, "rb") as f:
                         meta_pose = Pose.read(f, pose_body=EmptyPoseBody)
@@ -117,8 +112,8 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                     cache[cache_key] = {"hash": video_hash, "fps": fps, "total_frames": total_frames}
                     cache_dirty = True
 
-                pose_path = os.path.join(poses_dir, f"{video_hash}.pose")
-                if not os.path.exists(pose_path):
+                pose_path = self.poses_dir / f"{video_hash}.pose"
+                if not pose_path.exists():
                     continue
 
                 person_sentences = [
@@ -131,9 +126,9 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                 all_glosses = [g for s in person_sentences for g in s["glosses"]]
                 sentence_spans = [{"start": s["start"], "end": s["end"]} for s in person_sentences]
 
-                self.items.append({
+                self._track_and_filter(cache_key, doc_split, {
                     "id": cache_key,
-                    "pose_path": pose_path,
+                    "pose_path": str(pose_path),
                     "fps": fps,
                     "total_frames": total_frames,
                     "glosses": all_glosses,
@@ -141,20 +136,33 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
                 })
 
         if cache_dirty:
-            self._save_cache(cache_path, cache)
+            self._save_cache(cache_file, cache)
 
-        print(f"DGSSegmentationDataset({split}): {len(self.items)} videos")
+        print(
+            f"DGSSegmentationDataset({split}): "
+            f"{len(self.items)} videos "
+            f"(train={len(self._all_split_ids[Split.TRAIN])}, "
+            f"dev={len(self._all_split_ids[Split.DEV])}, "
+            f"test={len(self._all_split_ids[Split.TEST])})"
+        )
 
-    def _load_cache(self, path: str) -> dict:
-        if os.path.exists(path):
-            with open(path) as f:
-                return json.load(f)
+    def get_split_manifest(self) -> dict:
+        return {
+            "dataset": self.dataset_name,
+            "splits_path": self.splits_path,
+            "splits": {
+                s.value: sorted(ids) for s, ids in self._all_split_ids.items()
+            },
+        }
+
+    def _load_cache(self, path: Path) -> dict:
+        if path.exists():
+            return json.loads(path.read_text())
         return {}
 
-    def _save_cache(self, path: str, cache: dict) -> None:
+    def _save_cache(self, path: Path, cache: dict) -> None:
         try:
-            with open(path, "w") as f:
-                json.dump(cache, f)
+            path.write_text(json.dumps(cache))
         except OSError:
             pass
 
@@ -167,12 +175,3 @@ class DGSSegmentationDataset(BaseSegmentationDataset):
             target_fps=getattr(args, "target_fps", None),
             **augment_kwargs,
         )
-
-    def get_split_manifest(self) -> dict:
-        """return manifest of video IDs per split for reproducibility tracking."""
-        return {
-            "dataset": "dgs",
-            "split": self.split.value,
-            "video_ids": [item["id"] for item in self.items],
-        }
-

--- a/sign_language_segmentation/datasets/dgs/utils.py
+++ b/sign_language_segmentation/datasets/dgs/utils.py
@@ -1,0 +1,78 @@
+import pympi
+from pathlib import Path
+
+def is_joke(corpus_dir: Path, doc_id: str) -> bool:
+    cmdi_path = corpus_dir / "videos" / doc_id / "data.cmdi"
+    if not cmdi_path.exists():
+        return False
+    return "<cmdp:Task>Joke</cmdp:Task>" in cmdi_path.read_text()
+
+def get_elan_sentences(elan_path: str):
+    eaf = pympi.Elan.Eaf(elan_path)  # TODO add "suppress_version_warning=True" when pympi 1.7 is released
+
+    timeslots = eaf.timeslots
+
+    for participant in ["A", "B"]:
+        german_tier_name = "Deutsche_Übersetzung_" + participant
+        if german_tier_name not in eaf.tiers:
+            continue
+
+        german_text = eaf.tiers[german_tier_name][0]
+
+        english_tier_name = "Translation_into_English_" + participant
+        english_text = list(eaf.tiers[english_tier_name][0].values()) if english_tier_name in eaf.tiers else []
+
+        all_glosses = []
+        for hand in ["r", "l"]:
+            hand_tier = "Lexem_Gebärde_" + hand + "_" + participant
+            if hand_tier not in eaf.tiers:
+                continue
+
+            gloss = {
+                _id: {"start": timeslots[s], "end": timeslots[e], "gloss": val, "hand": hand}
+                for _id, (s, e, val, _) in eaf.tiers[hand_tier][0].items()
+            }
+            for tier in ["Lexeme_Sign", "Gebärde", "Sign"]:
+                items = eaf.tiers[tier + "_" + hand + "_" + participant][1]
+                for ref, val, _1, _2 in items.values():
+                    if ref in gloss:  # 2 files have a missing reference
+                        gloss[ref][tier] = val
+
+            all_glosses += list(gloss.values())
+
+        all_mouthings = []
+
+        tier_name = "Mundbild_Mundgestik_" + participant
+        items = eaf.tiers[tier_name][0]
+
+        # structure of entries:
+        # {'a2768296': ('ts42', 'ts43', 'tochter', None), ... }
+
+        for s, e, val, _ in items.values():
+            mouthing_entry = {"start": timeslots[s], "end": timeslots[e], "mouthing": val}
+            all_mouthings.append(mouthing_entry)
+
+        for _id, (s, e, val, _) in german_text.items():
+            sentence = {"id": _id, "participant": participant, "start": timeslots[s], "end": timeslots[e], "german": val}
+
+            # Add English sentence
+            english_sentence = [val2 for (s2, e2, val2, _) in english_text if s == s2 and e == e2]
+            sentence["english"] = english_sentence[0] if len(english_sentence) > 0 else None
+
+            # Add glosses
+            sentence["glosses"] = list(
+                sorted(
+                    [item for item in all_glosses if item["start"] >= sentence["start"] and item["end"] <= sentence["end"]],
+                    key=lambda d: d["start"],
+                )
+            )
+
+            # add mouthings
+            sentence["mouthings"] = list(
+                sorted(
+                    [item for item in all_mouthings if item["start"] >= sentence["start"] and item["end"] <= sentence["end"]],
+                    key=lambda d: d["start"],
+                )
+            )
+
+            yield sentence

--- a/sign_language_segmentation/evaluate.py
+++ b/sign_language_segmentation/evaluate.py
@@ -6,9 +6,8 @@ matching the evaluation protocol from the EMNLP 2023 paper.
 import argparse
 
 import torch
-from torch.utils.data import DataLoader
 
-from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
+from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.utils.bio import BIO
 from sign_language_segmentation.metrics import (
     frame_f1, likeliest_probs_to_segments,
@@ -94,15 +93,16 @@ if __name__ == "__main__":
     fps_aug = getattr(model.hparams, 'fps_aug', False)
     velocity = getattr(model.hparams, 'velocity', True)
 
-    dataset = build_datasets(
-        names=eval_args.datasets,
+    dataloader = get_dataloader(
         split=Split(eval_args.split),
+        dataset_names=eval_args.datasets,
         args=eval_args,
+        batch_size=1,
         num_frames=999999,
+        persistent_workers=False,
         fps_aug=fps_aug,
         velocity=velocity,
     )
-    dataloader = DataLoader(dataset, batch_size=1, collate_fn=collate_fn)
 
     def seg_fn(lp):
         segs = likeliest_probs_to_segments(lp)

--- a/sign_language_segmentation/tests/test_common.py
+++ b/sign_language_segmentation/tests/test_common.py
@@ -43,7 +43,6 @@ class TestDatasetRegistry:
             def __init__(self): ...
             @classmethod
             def from_args(cls, split, args, **kw): return cls()
-            def get_split_manifest(self): return {}
 
         register_dataset("_test_dummy", _Dummy)
         assert DATASET_REGISTRY["_test_dummy"] is _Dummy
@@ -285,6 +284,8 @@ class TestBaseSegmentationDataset:
 
     def test_subclass_inherits_len_and_getitem(self):
         class DummyDataset(BaseSegmentationDataset):
+            dataset_name = "dummy"
+
             def __init__(self):
                 self.items = [{"id": "test"}]
                 self.split = Split.TRAIN
@@ -293,14 +294,15 @@ class TestBaseSegmentationDataset:
                 self.fps_aug = False
                 self.frame_dropout = 0.0
                 self.body_part_dropout = 0.0
+                self.split_seed = 42
+                self._init_split_tracking()
 
             @classmethod
             def from_args(cls, split, args, **kw):
                 return cls()
 
-            def get_split_manifest(self) -> dict:
-                return {"dataset": "dummy"}
-
         ds = DummyDataset()
         assert len(ds) == 1
-        assert ds.get_split_manifest() == {"dataset": "dummy"}
+        manifest = ds.get_split_manifest()
+        assert manifest["dataset"] == "dummy"
+        assert manifest["split_seed"] == 42

--- a/sign_language_segmentation/train.py
+++ b/sign_language_segmentation/train.py
@@ -6,10 +6,10 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.loggers import WandbLogger
-from torch.utils.data import ConcatDataset, DataLoader, Dataset
+from torch.utils.data import ConcatDataset, Dataset
 
 from sign_language_segmentation.args import args
-from sign_language_segmentation.datasets.common import Split, build_datasets, collate_fn
+from sign_language_segmentation.datasets.common import Split, get_dataloader
 from sign_language_segmentation.model.model import PoseTaggingModel
 
 
@@ -27,33 +27,6 @@ def _collect_split_manifest(dataset: Dataset, dataset_names: str) -> dict:
         "datasets": dataset_names,
         "manifests": manifests,
     }
-
-
-def get_dataloader(
-    split: Split,
-    dataset_names: str,
-    batch_size: int | None = None,
-    num_frames: int | None = None,
-    persistent_workers: bool = True,
-) -> DataLoader:
-    augment_kwargs = dict(
-        num_frames=num_frames if num_frames is not None else args.num_frames,
-        velocity=args.velocity,
-        fps_aug=args.fps_aug,
-        frame_dropout=args.frame_dropout,
-        body_part_dropout=args.body_part_dropout if split == Split.TRAIN else 0.0,
-    )
-    dataset = build_datasets(names=dataset_names, split=split, args=args, **augment_kwargs)
-    return DataLoader(
-        dataset,
-        batch_size=batch_size or args.batch_size,
-        shuffle=(split == Split.TRAIN),
-        collate_fn=collate_fn,
-        num_workers=8,
-        persistent_workers=persistent_workers,
-        prefetch_factor=4 if persistent_workers else 2,
-        pin_memory=True,
-    )
 
 
 _DEFAULT_MONITOR_METRIC = "validation_hm_iou"
@@ -94,8 +67,8 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
         effective_args = {**vars(args), **overrides}
         logger.log_hyperparams(effective_args)
 
-    train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, batch_size=_get("batch_size"))
-    validation_loader = get_dataloader(Split.DEV, dataset_names=args.datasets, batch_size=1)
+    train_loader = get_dataloader(Split.TRAIN, dataset_names=args.datasets, args=args, batch_size=_get("batch_size"))
+    validation_loader = get_dataloader(Split.DEV, dataset_names=args.datasets, args=args, batch_size=1)
 
     example_datum = train_loader.dataset[0]
     pose_joints, pose_dims = example_datum["pose"].shape[1:3]
@@ -135,8 +108,6 @@ def train(overrides: dict | None = None, monitor_metric: str = _DEFAULT_MONITOR_
 
     # write split manifest
     manifest = _collect_split_manifest(train_loader.dataset, args.datasets)
-    val_manifest = _collect_split_manifest(validation_loader.dataset, args.datasets)
-    manifest["manifests"].extend(val_manifest["manifests"])
     manifest_path = model_dir / "split_manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     print(f"Split manifest: {manifest_path}")


### PR DESCRIPTION
## Stack
Stacked PR 1 of 5. Base of the stack; targets `main`.

## Summary
- Add a dataset registry, shared dataloader construction, and `all` dataset selection.
- Move generated dataset cache metadata under project `.cache/`.
- Remove the DGS runtime dependency on `sign_language_datasets` by keeping local DGS parsing helpers.

## Tests
- `uv run pytest` on `public-stack/dataset-foundation`: 38 passed